### PR TITLE
New test and handling for maybe_compare_idx==None; fixes TypeError causing Pynguin to abort.

### DIFF
--- a/src/pynguin/instrumentation/instrumentation.py
+++ b/src/pynguin/instrumentation/instrumentation.py
@@ -411,7 +411,7 @@ class BranchCoverageInstrumentation(InstrumentationAdapter):
         Returns:
             The id that was assigned to the predicate.
         """
-        maybe_compare = block[maybe_compare_idx]  # type: ignore[index]
+        maybe_compare = None if maybe_compare_idx is None else block[maybe_compare_idx]  # type: ignore[index]
         if (
             maybe_compare is not None
             and isinstance(maybe_compare, Instr)

--- a/tests/instrumentation/test_instrumentation.py
+++ b/tests/instrumentation/test_instrumentation.py
@@ -491,6 +491,26 @@ def test_exception_no_match_integrate():
     assert {0: 0.0} == tracer.get_trace().false_distances
 
 
+def test_jump_if_true_or_pop():
+    tracer = ExecutionTracer()
+
+    def func(string, inttype=int):
+        return ((
+                hasattr(string, "is_integer") or hasattr(string, "__array__")
+            )
+            or (
+                isinstance(string, (bytes, str))
+            )
+        )
+    
+    adapter = BranchCoverageInstrumentation(tracer)
+    transformer = InstrumentationTransformer(tracer, [adapter])
+    func.__code__ = transformer.instrument_module(func.__code__)
+
+    # FIXME execute func()
+    # FIXME add any appropriate exceptions
+
+
 def test_tracking_covered_statements_explicit_return(simple_module):
     tracer = ExecutionTracer()
 


### PR DESCRIPTION
The new test I include in this PR reproduces conditions that lead to `maybe_compare_idx == None` in  `_instrument_cond_jump` (from `instrumentation.py`), causing the error
```
TypeError: list indices must be integers or slices, not NoneType
```

I just added handling to avoid the `TypeError`;  Pynguin maintainers, please decide if this is the right thing to do, and provide any appropriate assertions in the new test.

This was tested with Python 3.10.12, as distributed by homebrew, on a MacOS system.