### PR TITLE
Add support for parsing module aliases

### DIFF
--- a/src/pynguin/testcase/execution.py
+++ b/src/pynguin/testcase/execution.py
@@ -2016,6 +2016,9 @@ class ModuleProvider:
             except AttributeError as e:
                 raise error from e
 
+            if not inspect.ismodule(submodule):
+                raise error
+
             return submodule
 
     def get_module(self, module_name: str) -> ModuleType:

--- a/tests/analyses/test_module.py
+++ b/tests/analyses/test_module.py
@@ -81,6 +81,16 @@ def test_parse_native_module():
     module.LOGGER.debug.assert_called_once()
 
 
+def test_parse_alias_module():
+    module.LOGGER = MagicMock(Logger)
+    module_name = "tests.fixtures.cluster.dependency"
+    alias_name = "tests.fixtures.cluster.alias_module.dep"
+    parse_result = parse_module(alias_name)
+    assert parse_result.module.__name__ == module_name
+    assert parse_result.module_name == alias_name
+    assert parse_result.syntax_tree is not None
+
+
 def test_analyse_module(parsed_module_no_dependencies):
     test_cluster = analyse_module(parsed_module_no_dependencies)
     assert test_cluster.num_accessible_objects_under_test() == 4

--- a/tests/fixtures/cluster/alias_module.py
+++ b/tests/fixtures/cluster/alias_module.py
@@ -1,0 +1,14 @@
+#  This file is part of Pynguin.
+#
+#  SPDX-FileCopyrightText: 2019–2023 Pynguin Contributors
+#
+#  SPDX-License-Identifier: MIT
+#
+from tests.fixtures.cluster import dependency
+
+
+dep = dependency
+
+
+def foo(x: int) -> int:
+    return x * 2


### PR DESCRIPTION
Hello,

Thank you for creating this project. I think I've discovered a bug that I've explained in issue #57 and I'm making this pull request to try to fix the problem.

My solution consists of a fallback when importing a module in order to deal with the case where the module is in fact an alias of another module such as `numpy.char` for example.

What do you think of this solution?

Kind regards and have a nice day!