### PR TITLE
Fix infinite loops in global scope

### DIFF
--- a/src/pynguin/analyses/controlflow.py
+++ b/src/pynguin/analyses/controlflow.py
@@ -544,6 +544,16 @@ class CFG(ProgramGraph[ProgramGraphNode]):
                 cfg.add_edge(predecessor_node, successor_node, **attrs)
 
     @staticmethod
+    def _infinite_loop_nodes(cfg: CFG) -> set[ProgramGraphNode]:
+        nodes: set[ProgramGraphNode] = set()
+        exit_nodes = cfg.exit_nodes
+        for node in cfg.nodes:
+            successors = cfg.get_successors(node)
+            if node in successors and successors.isdisjoint(exit_nodes):
+                nodes.add(node)
+        return nodes
+
+    @staticmethod
     def _insert_dummy_entry_node(cfg: CFG) -> CFG:
         dummy_entry_node = ProgramGraphNode(index=-1, is_artificial=True)
         # Search node with index 0. This block contains the instruction where
@@ -567,6 +577,8 @@ class CFG(ProgramGraph[ProgramGraphNode]):
         cfg.add_node(dummy_exit_node)
         for exit_node in exit_nodes:
             cfg.add_edge(exit_node, dummy_exit_node)
+        for infinite_loop_node in CFG._infinite_loop_nodes(cfg):
+            cfg.add_edge(infinite_loop_node, dummy_exit_node)
         return cfg
 
     @property


### PR DESCRIPTION
Fix #63 

Hi,

The problem is described in the referenced issue. I've fixed it by linking nodes doing infinite loops to the dummy exit node. Since the problem comes from an optimisation of Python, I wasn't sure whether indirect infinite loops could occur in the bytecode, so I dealt with that case too, just in case.

Example of an indirect infinite loop (even if I don't know if it's possible to create it except artificially):

![Indirect infinite loop](https://github.com/se2p/pynguin/assets/55436804/689c1f96-53ba-4114-a844-1d778c5ac227)

If this can't happen, we could simplify the code and just link the nodes that are their only successors (`{node} == cfg.get_successors(node)`) to the dummy exit node.

The resulting augmented graph looks like that (to compare with the graph of the issue):

![New augmented graph](https://github.com/se2p/pynguin/assets/55436804/dc089a8c-3967-47da-9c45-98fab11d937e)

I still wonder whether this is a good solution or not because I saw that there was an assertion that prevents code from being executed when it detects a "while true" loop with no exit node. The difference with this case is that the infinite loop only occurs under certain circumstances because of an if statement. If we block this kind of case with an assertion too, it will prevent testing the other branch of the if statement, so it's not perfect either. I've also noticed that the problem can occur in functions, so to fix the original issue, we would have needed to allow disabling the `if __name__ == "__main__"` as well as certain functions that have "while true" loops to fix that perfectly.

```python
def foo(x: bool):
    if x:
        while True:
            pass
```

So what do you think, I'm not really an expert in this kind of graph but I hope my solution suits you. Don't hesitate if you have any comments or questions.

Have a nice day!