### PR TITLE
Fix assertion error when analyzing a sklearn module

### DIFF
--- a/src/pynguin/analyses/syntaxtree.py
+++ b/src/pynguin/analyses/syntaxtree.py
@@ -319,7 +319,7 @@ class _RaiseVisitor(ast.NodeVisitor):
     def visit_Raise(self, node: ast.Raise) -> ast.AST:  # noqa: N802
         bubbles = self.context.add_exception(node)
         if bubbles:
-            assert len(self.contexts) > 1
+            assert len(self.contexts) >= 1
             if len(self.contexts) < 2:
                 return self.generic_visit(node)
             parent_context = self.contexts[-2]
@@ -378,7 +378,11 @@ class _RaiseVisitor(ast.NodeVisitor):
         # exceptions.
         self.visit_Raise(
             ast.Raise(
-                exc=ast.Call(func=ast.Name(id="AssertionError", ctx=ast.Load())),
+                exc=ast.Call(
+                    func=ast.Name(id="AssertionError", ctx=ast.Load()),
+                    args=[],
+                    keywords=[],
+                ),
             )
         )
         # Make sure that we also execute a visit_Assert method in another analysis


### PR DESCRIPTION
Hi,

This pull request fixes the bug I've explained in issue #71.

I'm pretty sure that the problem is just an error in the assertion because if `len(self.contexts) > 1` at the line 322, then the condition `len(self.contexts) < 2` in the if statement at line 323 will never be `True` since there is no integer `x` that verifies the proposition `1 < x < 2`. I've added a `=` in the assertion to fix the bug.

I changed the other part of the code because while I was looking for the source of the bug, I often converted the AST to a string using the `ast.unparse` function and this function crashed because some of the arguments of the `ast.Call` node were missing. I'm pretty sure this is also a small bug.

Have a nice day!