### PR TITLE
Migrate to modern datetime API

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -27,7 +27,7 @@ extensions = [
 
 project = "pynguin"
 author = "Pynguin Contributors"
-copyright = f"2019–{datetime.datetime.utcnow().year}, {author}"
+copyright = f"2019–{datetime.datetime.now(datetime.timezone.utc).year}, {author}"
 html_theme = "sphinx_rtd_theme"
 
 _d = {}


### PR DESCRIPTION
# PR Summary
This small PR resolves the `datetime` library warnings:
```python
DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC). or datetime.datetime.utcnow()
```