### PR TITLE
Add an error message in setup_test_cluster in case of a ModuleNotFoundError

### DIFF
--- a/src/pynguin/generator.py
+++ b/src/pynguin/generator.py
@@ -130,10 +130,20 @@ def run_pynguin() -> ReturnCode:
 
 
 def _setup_test_cluster() -> ModuleTestCluster | None:
-    test_cluster = generate_test_cluster(
-        config.configuration.module_name,
-        config.configuration.type_inference.type_inference_strategy,
-    )
+    try:
+        test_cluster = generate_test_cluster(
+            config.configuration.module_name,
+            config.configuration.type_inference.type_inference_strategy,
+        )
+    except ModuleNotFoundError as ex:
+        _LOGGER.exception(
+            """Module %s could not be found. This is likely due to a missing dependency.
+            It may also be caused by a bug in the SUT, especially if it uses C-modules.
+            """,
+            ex.name,
+        )
+        return None
+
     if test_cluster.num_accessible_objects_under_test() == 0:
         _LOGGER.error("SUT contains nothing we can test.")
         return None


### PR DESCRIPTION
Hi,

I'm making this pull request to add an error message in case Pynguin fails to find a module. Most of the time, this is due to a missing dependency caused by either an installation issue or an optional dependency. However, this may also be caused by a bug in the SUT, as in this case: https://github.com/alan-turing-institute/CleverCSV/issues/128.

For now, this just makes Pynguin crash with an exception which isn't very clear to users. That's why I think the addition of an error message seems like a good idea.

I found this problem thanks to this stacktrace from the C modules benchmark:
```
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/site-packages/pynguin/analyses/module.py", line 257, in import_module
    submodule = getattr(package, submodule_name)
AttributeError: module 'torch._ops' has no attribute 'aten'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/usr/local/bin/pynguin", line 8, in <module>
    sys.exit(main())
  File "/usr/local/lib/python3.10/site-packages/pynguin/cli.py", line 213, in main
    return run_pynguin().value
  File "/usr/local/lib/python3.10/site-packages/pynguin/generator.py", line 125, in run_pynguin
    return _run()
  File "/usr/local/lib/python3.10/site-packages/pynguin/generator.py", line 516, in _run
    if (setup_result := _setup_and_check()) is None:
  File "/usr/local/lib/python3.10/site-packages/pynguin/generator.py", line 263, in _setup_and_check
    if (test_cluster := _setup_test_cluster()) is None:
  File "/usr/local/lib/python3.10/site-packages/pynguin/generator.py", line 131, in _setup_test_cluster
    test_cluster = generate_test_cluster(
  File "/usr/local/lib/python3.10/site-packages/pynguin/analyses/module.py", line 1495, in generate_test_cluster
    return analyse_module(parse_module(module_name), type_inference_strategy)
  File "/usr/local/lib/python3.10/site-packages/pynguin/analyses/module.py", line 1474, in analyse_module
    __resolve_dependencies(
  File "/usr/local/lib/python3.10/site-packages/pynguin/analyses/module.py", line 1343, in __resolve_dependencies
    __analyse_included_functions(
  File "/usr/local/lib/python3.10/site-packages/pynguin/analyses/module.py", line 1454, in __analyse_included_functions
    module_tree=parse_results[current.__module__].syntax_tree,
  File "/usr/local/lib/python3.10/site-packages/pynguin/analyses/module.py", line 1291, in __missing__
    res = self[key] = parse_module(key)
  File "/usr/local/lib/python3.10/site-packages/pynguin/analyses/module.py", line 281, in parse_module
    module = import_module(module_name)
  File "/usr/local/lib/python3.10/site-packages/pynguin/analyses/module.py", line 259, in import_module
    raise error from e
  File "/usr/local/lib/python3.10/site-packages/pynguin/analyses/module.py", line 244, in import_module
    return importlib.import_module(module_name)
  File "/usr/local/lib/python3.10/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1050, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1001, in _find_and_load_unlocked
ModuleNotFoundError: No module named 'torch._ops.aten'; 'torch._ops' is not a package
```

There were around 170 unique stacktraces of this type in the logs, so it would be very interesting to report this problem rather than raising an exception.

Have a nice day!
