### PR TITLE
Fix `configuration_writer.extract_parameter_list_from_config` that do not extract some parameters

### DIFF
--- a/src/pynguin/utils/configuration_writer.py
+++ b/src/pynguin/utils/configuration_writer.py
@@ -85,11 +85,11 @@ def extract_parameter_list_from_config(*, verbosity: bool = True) -> list[str]:
     cfg_dict = dataclasses.asdict(config.configuration)
 
     for key, value in cfg_dict.items():
-        if isinstance(value, str) and value:
-            parameter_list.append(format_parameter(key, value))
-        elif isinstance(value, dict):
+        if isinstance(value, (str, list)) and not value:
+            continue
+        if isinstance(value, dict):
             for sub_key, sub_value in value.items():
-                if isinstance(sub_value, str) and not sub_value:
+                if isinstance(sub_value, (str, list)) and not sub_value:
                     continue
                 if isinstance(sub_value, dict):
                     for sub_sub_key, sub_sub_value in sub_value.items():
@@ -98,6 +98,8 @@ def extract_parameter_list_from_config(*, verbosity: bool = True) -> list[str]:
                         )
                 else:
                     parameter_list.append(format_parameter(f"{sub_key}", sub_value))
+        else:
+            parameter_list.append(format_parameter(key, value))
 
     verbosity_params = _extract_verbosity_params() if verbosity else []
     return sorted(parameter_list + verbosity_params)

--- a/tests/utils/test_configuration_writer.py
+++ b/tests/utils/test_configuration_writer.py
@@ -316,6 +316,7 @@ def expected_parameter_list() -> list[str]:
         "--max_delta 20",
         "--max_int 2048",
         "--string_length 20",
+        "--subprocess False",
         "--bytes_length 20",
         "--collection_size 5",
         "--primitive_reuse_probability 0.5",


### PR DESCRIPTION
Hi,

While trying to replicate the results of a run from the C-modules benchmark, I noticed that the `--subprocess` argument was missing from some `pynguin-cli-params.txt` files. I've found that this is due to a bug in the `extract_parameter_list_from_config` function.