### PR TITLE
Improve the handling of non-imported modules during test generation

### DIFF
--- a/src/pynguin/testcase/execution.py
+++ b/src/pynguin/testcase/execution.py
@@ -70,6 +70,7 @@ from pynguin.instrumentation.tracer import ExecutionTracer
 from pynguin.instrumentation.tracer import InstrumentationExecutionTracer
 from pynguin.testcase import export
 from pynguin.utils import randomness
+from pynguin.utils.exceptions import ModuleNotImportedError
 from pynguin.utils.mirror import Mirror
 
 
@@ -775,19 +776,6 @@ class ExecutionResult:
 
     def __repr__(self) -> str:
         return str(self)
-
-
-class ModuleNotImportedError(Exception):
-    """Exception that is raised when trying to access a module that is not imported."""
-
-    def __init__(self, name: str) -> None:
-        """Create a new module not imported error.
-
-        Args:
-            name: The name of the module that was not imported
-        """
-        super().__init__(f"Module '{name}' is not imported.")
-        self.name = name
 
 
 class ModuleProvider:

--- a/src/pynguin/utils/exceptions.py
+++ b/src/pynguin/utils/exceptions.py
@@ -41,3 +41,16 @@ class SlicingTimeoutException(BaseException):
 
 class ConstraintValidationError(Exception):
     """Raised when a constraints for ML API contain faulty information."""
+
+
+class ModuleNotImportedError(Exception):
+    """Raised when trying to access a module that is not imported."""
+
+    def __init__(self, name: str) -> None:
+        """Create a new module not imported error.
+
+        Args:
+            name: The name of the module that was not imported
+        """
+        super().__init__(f"Module '{name}' is not imported.")
+        self.name = name

--- a/tests/fixtures/examples/module_alias.py
+++ b/tests/fixtures/examples/module_alias.py
@@ -1,0 +1,4 @@
+from tests.fixtures.examples import simple
+
+
+deprecated = simple

--- a/tests/fixtures/examples/module_alias.py
+++ b/tests/fixtures/examples/module_alias.py
@@ -1,3 +1,9 @@
+#  This file is part of Pynguin.
+#
+#  SPDX-FileCopyrightText: 2019–2025 Pynguin Contributors
+#
+#  SPDX-License-Identifier: MIT
+#
 from tests.fixtures.examples import simple
 
 

--- a/tests/testcase/execution/test_moduleprovider.py
+++ b/tests/testcase/execution/test_moduleprovider.py
@@ -4,11 +4,18 @@
 #
 #  SPDX-License-Identifier: MIT
 #
+import sys
+
 from unittest.mock import MagicMock
 
 import pytest
 
 import pynguin.testcase.execution as ex
+
+# Needs to be loaded to be in sys.modules
+import tests.fixtures.examples.module_alias  # noqa: F401
+
+from tests.fixtures.examples import simple
 
 
 @pytest.fixture
@@ -39,6 +46,29 @@ def test_clear_mutated_modules(module_provider):
     assert len(module_provider._mutated_module_aliases) == 0
 
 
-def test_module_not_imported(module_provider):
+def test_get_valid_module(module_provider):
+    assert sys == module_provider.get_module("sys")
+
+
+def test_get_invalid_module(module_provider):
     with pytest.raises(ex.ModuleNotImportedError):
         module_provider.get_module("foo")
+
+
+def test_get_invalid_submodule(module_provider):
+    with pytest.raises(ex.ModuleNotImportedError):
+        module_provider.get_module("sys.foo")
+
+
+def test_get_missing_submodule(module_provider):
+    with pytest.raises(ex.ModuleNotImportedError):
+        module_provider.get_module("tests.fixtures.examples.simple.foo")
+
+
+def test_get_valid_module_with_alias(module_provider):
+    assert simple == module_provider.get_module("tests.fixtures.examples.module_alias.deprecated")
+
+
+def test_get_invalid_module_with_alias(module_provider):
+    with pytest.raises(ex.ModuleNotImportedError):
+        module_provider.get_module("tests.fixtures.examples.simple.add")

--- a/tests/testcase/execution/test_moduleprovider.py
+++ b/tests/testcase/execution/test_moduleprovider.py
@@ -37,3 +37,8 @@ def test_clear_mutated_modules(module_provider):
     module_provider.add_mutated_version("foo", MagicMock())
     module_provider.clear_mutated_modules()
     assert len(module_provider._mutated_module_aliases) == 0
+
+
+def test_module_not_imported(module_provider):
+    with pytest.raises(ex.ModuleNotImportedError):
+        module_provider.get_module("foo")


### PR DESCRIPTION
Fix #97

I've fixed this issue by adding a custom exception which is caught independently to separate this expected case from other bugs that might occur in Pynguin.

I also took the opportunity to modify some behaviour in the assertion generation so that it logs the problems rather than silently ignoring them.