### PR TITLE
Add support for creating the report dir if it does not exist

### DIFF
--- a/src/pynguin/utils/configuration_writer.py
+++ b/src/pynguin/utils/configuration_writer.py
@@ -29,6 +29,8 @@ def write_configuration():
     if config.configuration.statistics_output.statistics_backend == config.StatisticsBackend.CSV:
         report_dir = Path(config.configuration.statistics_output.report_dir).resolve()
 
+        report_dir.mkdir(parents=True, exist_ok=True)
+
         # Write configuration to a TOML file
         toml_file = report_dir / PYNGUIN_CONFIG_TOML
         config_repr = convert_config_to_dict(config.configuration)


### PR DESCRIPTION
Hi,

I'm making this PR to fix a little bug with the report dir. It's an argument whose default value is `pynguin-report` but if it doesn't exist, Pynguin crashes with an exception which is not very clear. So I've just added an instruction that will automatically create the report dir if it doesn't exist