### PR TITLE
Add e2e tests for data reproducibility

### DIFF
--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -57,7 +57,7 @@ def run_pynguin(
         cwd=tmpdir_path,
         env={
             "PYNGUIN_DANGER_AWARE": "1",
-            # disabled to check reproducibility: "PYTHONHASHSEED": str(seed),
+            "PYTHONHASHSEED": str(seed),
             **os.environ,
         },
     )


### PR DESCRIPTION
Hi,

I'm making this PR to add e2e tests to check that 2 runs with the same seed will return the same results if they have the same arguments and the same number of iterations.

I noticed that this wasn't the case on my PC, so I wanted to check whether this also happened in the CI and on other PCs. Nevertheless, I found that by setting the `PYTHONHASHSEED` environment variable to a fixed value, runs became deterministic again on my PC. This could show that there is a misuse of a set or a dictionary in Pynguin that makes runs non-deterministic.
