### PR TITLE
Removal of unnecessary log messages in case of test execution timeouts

### DIFF
--- a/src/pynguin/instrumentation/tracer.py
+++ b/src/pynguin/instrumentation/tracer.py
@@ -42,6 +42,7 @@ import pynguin.utils.typetracing as tt
 
 from pynguin.instrumentation import PynguinCompare
 from pynguin.instrumentation import version
+from pynguin.utils.exceptions import TracingAbortedException
 from pynguin.utils.orderedset import OrderedSet
 from pynguin.utils.type_utils import given_exception_matches
 from pynguin.utils.type_utils import is_bytes
@@ -1147,7 +1148,9 @@ class ExecutionTracer(AbstractExecutionTracer):  # noqa: PLR0904
 
     def check(self) -> None:  # noqa: D102
         if threading.current_thread().ident != self._current_thread_identifier:
-            raise RuntimeError("The current thread shall not be executed any more, thus I kill it.")
+            raise TracingAbortedException(
+                "The current thread shall not be executed anymore, thus I kill it."
+            )
 
     @property
     def import_trace(self) -> ExecutionTrace:  # noqa: D102

--- a/src/pynguin/testcase/execution.py
+++ b/src/pynguin/testcase/execution.py
@@ -68,6 +68,7 @@ from pynguin.testcase import export
 from pynguin.utils import randomness
 from pynguin.utils.exceptions import MinimizationFailureError
 from pynguin.utils.exceptions import ModuleNotImportedError
+from pynguin.utils.exceptions import TracingAbortedException
 from pynguin.utils.mirror import Mirror
 
 
@@ -1120,6 +1121,8 @@ class TestCaseExecutor(AbstractTestCaseExecutor):
                 exc_info=True,
             )
             result = ExecutionResult(timeout=True)
+        except TracingAbortedException:
+            return
 
         result_queue.put(result)
 

--- a/src/pynguin/testcase/execution.py
+++ b/src/pynguin/testcase/execution.py
@@ -991,22 +991,6 @@ class TestCaseExecutor(AbstractTestCaseExecutor):
             [checked_instrumentation],
         )
 
-        def log_thread_exception(arg: threading.ExceptHookArgs) -> None:
-            _LOGGER.warning(
-                "Exception in Thread: %s",
-                arg.thread,
-                exc_info=(  # noqa: LOG014
-                    arg.exc_type,
-                    arg.exc_value,  # type: ignore[arg-type]
-                    arg.exc_traceback,
-                ),
-            )
-
-        # Set our own exception hook, so timeout related errors in executing threads
-        # are not spilled out to stderr and clutter our formatted output but are send
-        # to the logger
-        threading.excepthook = log_thread_exception
-
     @property
     def module_provider(self) -> ModuleProvider:  # noqa: D102
         return self._module_provider

--- a/src/pynguin/utils/exceptions.py
+++ b/src/pynguin/utils/exceptions.py
@@ -58,3 +58,7 @@ class MinimizationFailureError(Exception):
 
 class CoroutineFoundException(BaseException):
     """Raised when a coroutine is found in the SUT, which Pynguin cannot handle."""
+
+
+class TracingAbortedException(BaseException):
+    """Raised to abort tracing."""

--- a/tests/instrumentation/test_tracer.py
+++ b/tests/instrumentation/test_tracer.py
@@ -21,6 +21,7 @@ from pynguin.instrumentation.tracer import LineMetaData
 from pynguin.instrumentation.tracer import SubjectProperties
 from pynguin.instrumentation.tracer import _le  # noqa: PLC2701
 from pynguin.instrumentation.tracer import _lt  # noqa: PLC2701
+from pynguin.utils.exceptions import TracingAbortedException
 from pynguin.utils.orderedset import OrderedSet
 
 
@@ -529,7 +530,7 @@ def test_code_object_executed_other_thread(subject_properties: SubjectProperties
     subject_properties.register_code_object(0, MagicMock())
 
     def wrapper(*args):
-        with pytest.raises(RuntimeError):
+        with pytest.raises(TracingAbortedException):
             subject_properties.instrumentation_tracer.executed_code_object(*args)
 
     thread = threading.Thread(target=wrapper, args=(0,))
@@ -548,7 +549,7 @@ def test_bool_predicate_executed_other_thread(subject_properties: SubjectPropert
     subject_properties.register_code_object(1, MagicMock(code_object_id=0))
 
     def wrapper(*args):
-        with pytest.raises(RuntimeError):
+        with pytest.raises(TracingAbortedException):
             subject_properties.instrumentation_tracer.executed_bool_predicate(*args)
 
     thread = threading.Thread(target=wrapper, args=(True, 0))
@@ -565,7 +566,7 @@ def test_compare_predicate_executed_other_thread(subject_properties: SubjectProp
     subject_properties.register_code_object(1, MagicMock(code_object_id=0))
 
     def wrapper(*args):
-        with pytest.raises(RuntimeError):
+        with pytest.raises(TracingAbortedException):
             subject_properties.instrumentation_tracer.executed_compare_predicate(*args)
 
     thread = threading.Thread(target=wrapper, args=(True, False, PynguinCompare.EQ, 0))
@@ -588,5 +589,5 @@ def test_compare_predicate_executed_other_thread(subject_properties: SubjectProp
     ],
 )
 def test_killed_by_thread_guard(method, inputs, subject_properties: SubjectProperties):
-    with pytest.raises(RuntimeError):
+    with pytest.raises(TracingAbortedException):
         getattr(subject_properties.instrumentation_tracer, method)(*inputs)


### PR DESCRIPTION
Hi,

I noticed that when analysing errors in the benchmarks, we often found exceptions caused by the tracer in case of test execution timeouts. However, these exceptions are part of Pynguin's expected behaviour, do not provide useful debugging information, and may potentially confuse users. Therefore, I created a `TracingAbortedException` class so that we can more easily ignore these exceptions.

I also moved the code responsible for logging unexpected errors to a more global location because, currently, a global variable of the `threading` module was being reassigned each time a `TestCaseExecutor` was created, which was not very pertinent.