### PR TITLE
Prevent destructors from being explicitly called during test generation

### DIFF
--- a/src/pynguin/analyses/module.py
+++ b/src/pynguin/analyses/module.py
@@ -1467,6 +1467,7 @@ def __analyse_class(
 IGNORED_SYMBOLS: set[str] = {
     "__new__",
     "__init__",
+    "__del__",
     "__repr__",
     "__str__",
     "__sizeof__",


### PR DESCRIPTION
Hi,

In the benchmarks, crashes were detected on several occasions due to explicit calls to the destructors ([\_\_del\_\_](https://docs.python.org/3/reference/datamodel.html#object.__del__)) of some objects. However, these methods are never intended to be called explicitly, and when they are, they will likely put the objects in unstable states. Therefore, it is preferable to prevent Pynguin from calling these destructors explicitly in my opinion.