### PR TITLE
Fix some bugs caused by `pragma: no cover`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -285,7 +285,7 @@ convention = "google"
 
 [tool.tox]
 requires = ["tox~=4.28"]
-env_list = ["3.10", "3.11", "3.12", "3.13"]
+env_list = ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
 [tool.tox.env_run_base]
 skip_install = true

--- a/src/pynguin/analyses/module.py
+++ b/src/pynguin/analyses/module.py
@@ -1137,6 +1137,7 @@ class FilteredModuleTestCluster(TestCluster):  # noqa: PLR0904
             for acc in delegate.accessible_objects_under_test
             if isinstance(acc, GenericCallableAccessibleObject)
             and hasattr(acc.callable, "__code__")
+            and acc.callable.__code__ in existing_code_objects
         }
         # Checking for __code__ is necessary, because the __init__ of a class that
         # does not define __init__ points to some internal CPython stuff.

--- a/src/pynguin/instrumentation/transformer.py
+++ b/src/pynguin/instrumentation/transformer.py
@@ -282,7 +282,7 @@ class AstInfo:
         if (
             isinstance(branch_node.parent, If)
             and branch_node.parent.has_elif_block()
-            and branch_node.body[0] == branch_node
+            and branch_node.parent.orelse[0] == branch_node
         ):
             return AstInfo._get_parent_if(branch_node.parent)
 

--- a/src/pynguin/instrumentation/transformer.py
+++ b/src/pynguin/instrumentation/transformer.py
@@ -321,7 +321,9 @@ class AstInfo:
         """Check if a line number should be covered.
 
         This means that the instruction itself must be in the cover lines, as well as
-        all conditional instructions in which it is contained.
+        all conditional instructions in which it is contained. In other words, if the instruction
+        itself or any of its conditional instructions are part of the `no_cover_lines`, the line
+        should not be covered.
 
         Args:
             lineno: The line number.

--- a/src/pynguin/instrumentation/transformer.py
+++ b/src/pynguin/instrumentation/transformer.py
@@ -422,7 +422,8 @@ class AstInfo:
         """
         for branch_node in self.ast.nodes_of_class(If | For | While | MatchCase):
             if branch_node.fromlineno == lineno or (
-                isinstance(branch_node, If | For) and lineno in self._else_lines(branch_node)
+                isinstance(branch_node, If | For | While)
+                and lineno in self._else_lines(branch_node)
             ):
                 return self.should_cover_line(branch_node.fromlineno) and (
                     isinstance(branch_node, MatchCase)

--- a/src/pynguin/instrumentation/transformer.py
+++ b/src/pynguin/instrumentation/transformer.py
@@ -289,7 +289,7 @@ class AstInfo:
         return branch_node
 
     def _all_branches_in_cover(self, branch_node: If | While | For) -> bool:
-        if not self._in_cover(branch_node.fromlineno):
+        if not self.should_cover_line(branch_node.fromlineno):
             return False
 
         if isinstance(branch_node, If) and branch_node.has_elif_block():
@@ -297,7 +297,7 @@ class AstInfo:
             return self._all_branches_in_cover(branch_node.orelse[0])
 
         return isinstance(branch_node, While) or all(
-            self._in_cover(else_lineno) for else_lineno in self._else_lines(branch_node)
+            self.should_cover_line(else_lineno) for else_lineno in self._else_lines(branch_node)
         )
 
     def should_be_covered(self) -> bool:
@@ -364,7 +364,8 @@ class AstInfo:
     def should_cover_conditional_statement(self, lineno: int) -> bool:
         """Check if the conditional statement at the line number should be covered.
 
-        This means that the conditional statement must have all its branches in the cover lines.
+        This means that the conditional statement must have all its branches in the cover lines,
+        as well as all conditional instructions in which it is contained.
 
         Args:
             lineno: The line number of the conditional statement.

--- a/src/pynguin/instrumentation/transformer.py
+++ b/src/pynguin/instrumentation/transformer.py
@@ -29,6 +29,8 @@ from astroid.nodes import Match
 from astroid.nodes import MatchCase
 from astroid.nodes import Module
 from astroid.nodes import NodeNG
+from astroid.nodes import Try
+from astroid.nodes import TryStar
 from astroid.nodes import While
 from bytecode import Bytecode
 from bytecode.instr import Instr
@@ -272,12 +274,33 @@ class AstInfo:
         return bool(body) and body[0].fromlineno <= lineno <= body[-1].tolineno
 
     @staticmethod
-    def _else_lines(branch_node: If | For) -> Iterable[int]:
-        if branch_node.body and branch_node.orelse:
+    def _inter_lines(previous_body: list[NodeNG], after_body: list[NodeNG]) -> Iterable[int]:
+        if previous_body and after_body:
             yield from range(
-                branch_node.body[-1].tolineno + 1,
-                branch_node.orelse[0].fromlineno,
+                previous_body[-1].tolineno + 1,
+                after_body[0].fromlineno,
             )
+
+    @staticmethod
+    def _else_lines(node: If | For) -> Iterable[int]:
+        return AstInfo._inter_lines(node.body, node.orelse)
+
+    @staticmethod
+    def _try_else_lines(node: Try | TryStar) -> Iterable[int]:
+        if node.handlers:
+            return AstInfo._inter_lines(node.handlers[-1].body, node.orelse)
+
+        return AstInfo._inter_lines(node.body, node.orelse)
+
+    @staticmethod
+    def _try_finally_lines(node: Try | TryStar) -> Iterable[int]:
+        if node.orelse:
+            return AstInfo._inter_lines(node.orelse, node.finalbody)
+
+        if node.handlers:
+            return AstInfo._inter_lines(node.handlers[-1].body, node.finalbody)
+
+        return AstInfo._inter_lines(node.body, node.finalbody)
 
     def should_be_covered(self) -> bool:
         """Check if self should be covered.
@@ -310,39 +333,59 @@ class AstInfo:
         if not self._in_cover(lineno):
             return False
 
-        # Handle branches
-        for branch_node in self.ast.nodes_of_class(If | For | While | Match):
+        for branch_node in self.ast.nodes_of_class(If | For | While | Match | Try | TryStar):
             # Skip nodes that do not contains the lineno
             if lineno < branch_node.fromlineno or branch_node.tolineno < lineno:
                 continue
 
-            # Check the "match" branches
-            if isinstance(branch_node, Match):
-                return branch_node.fromlineno not in self.module.no_cover_lines and all(
-                    case_node.fromlineno not in self.module.no_cover_lines
+            if isinstance(branch_node, Match) and (
+                branch_node.fromlineno in self.module.no_cover_lines
+                or any(
+                    case_node.fromlineno in self.module.no_cover_lines
                     for case_node in branch_node.cases
                     if self._in_body(case_node.body, lineno)
                 )
+            ):
+                return False
 
-            # Check the "True" branch
             if (
-                self._in_body(branch_node.body, lineno)
+                isinstance(branch_node, If | For | While | Try | TryStar)
+                and self._in_body(branch_node.body, lineno)
                 and branch_node.fromlineno in self.module.no_cover_lines
             ):
                 return False
 
-            # Do not check for a "else" when there is a "elif" or in a "while"
-            if (isinstance(branch_node, If) and branch_node.has_elif_block()) or isinstance(
-                branch_node, While
+            if isinstance(branch_node, Try | TryStar) and (  # noqa: PLR0916
+                any(
+                    handler_node.fromlineno in self.module.no_cover_lines
+                    for handler_node in branch_node.handlers
+                    if self._in_body(handler_node.body, lineno)
+                )
+                or (
+                    self._in_body(branch_node.orelse, lineno)
+                    and any(
+                        else_lineno in self.module.no_cover_lines
+                        for else_lineno in self._try_else_lines(branch_node)
+                    )
+                )
+                or (
+                    self._in_body(branch_node.finalbody, lineno)
+                    and any(
+                        final_lineno in self.module.no_cover_lines
+                        for final_lineno in self._try_finally_lines(branch_node)
+                    )
+                )
             ):
-                continue
+                return False
 
-            # Check the "False" branch
-            # We don't have access to the exact location of the else statement so we check
-            # all lines in which it could be defined for now
-            if self._in_body(branch_node.orelse, lineno) and any(
-                else_lineno in self.module.no_cover_lines
-                for else_lineno in self._else_lines(branch_node)
+            if (
+                isinstance(branch_node, If | For)
+                and (not isinstance(branch_node, If) or not branch_node.has_elif_block())
+                and self._in_body(branch_node.orelse, lineno)
+                and any(
+                    else_lineno in self.module.no_cover_lines
+                    for else_lineno in self._else_lines(branch_node)
+                )
             ):
                 return False
 

--- a/src/pynguin/instrumentation/transformer.py
+++ b/src/pynguin/instrumentation/transformer.py
@@ -282,7 +282,7 @@ class AstInfo:
             )
 
     @staticmethod
-    def _else_lines(node: If | For) -> Iterable[int]:
+    def _else_lines(node: If | For | While) -> Iterable[int]:
         return AstInfo._inter_lines(node.body, node.orelse)
 
     @staticmethod
@@ -379,7 +379,7 @@ class AstInfo:
                 return False
 
             if (
-                isinstance(branch_node, If | For)
+                isinstance(branch_node, If | For | While)
                 and (not isinstance(branch_node, If) or not branch_node.has_elif_block())
                 and self._in_body(branch_node.orelse, lineno)
                 and any(
@@ -409,7 +409,7 @@ class AstInfo:
                 isinstance(branch_node, If | For) and lineno in self._else_lines(branch_node)
             ):
                 return self.should_cover_line(branch_node.fromlineno) and (
-                    isinstance(branch_node, While | MatchCase)
+                    isinstance(branch_node, MatchCase)
                     or (isinstance(branch_node, If) and branch_node.has_elif_block())
                     or all(
                         self.should_cover_line(else_lineno)

--- a/src/pynguin/instrumentation/version/python3_10.py
+++ b/src/pynguin/instrumentation/version/python3_10.py
@@ -849,7 +849,7 @@ class BranchCoverageInstrumentation(transformer.BranchCoverageInstrumentationAda
         if (
             ast_info is not None
             and isinstance(maybe_jump.lineno, int)
-            and not ast_info.should_cover_line(maybe_jump.lineno)
+            and not ast_info.should_cover_conditional_statement(maybe_jump.lineno)
         ):
             return
 

--- a/src/pynguin/instrumentation/version/python3_11.py
+++ b/src/pynguin/instrumentation/version/python3_11.py
@@ -448,7 +448,7 @@ class BranchCoverageInstrumentation(python3_10.BranchCoverageInstrumentation):
         if (
             ast_info is not None
             and isinstance(maybe_jump.lineno, int)
-            and not ast_info.should_cover_line(maybe_jump.lineno)
+            and not ast_info.should_cover_conditional_statement(maybe_jump.lineno)
         ):
             return
 

--- a/tests/fixtures/instrumentation/covered_branches.py
+++ b/tests/fixtures/instrumentation/covered_branches.py
@@ -49,8 +49,8 @@ def no_cover_while(x: int) -> int:
     return x
 
 def no_cover_if_in_while(x: int) -> int:
-    while x > 0:  # pynguin: no cover
-        if x > 0:
+    while x > 0:
+        if x > 0:  # pynguin: no cover
             print(x)
         else:
             print(-x)

--- a/tests/fixtures/instrumentation/covered_branches.py
+++ b/tests/fixtures/instrumentation/covered_branches.py
@@ -67,3 +67,29 @@ def no_cover_for_else(x: int) -> int:
     else:  # pynguin: no cover
         print(-1)
     return x
+
+def no_cover_match(x: int) -> str:
+    match x:  # pynguin: no cover
+        case 1:
+            a = 1
+        case _:
+            a = 0
+    return str(a) * 2
+
+def no_cover_case(x: int) -> int:
+    match x:
+        case 1:  # pynguin: no cover
+            return 1
+        case 2:
+            return 2
+        case _:
+            return 0
+
+def no_cover_case_only_catchall(x: int) -> str:
+    a = -1
+    match x:
+        case 1:  # pynguin: no cover
+            a = 1
+        case _:
+            a = 0
+    return str(a)

--- a/tests/fixtures/instrumentation/covered_branches.py
+++ b/tests/fixtures/instrumentation/covered_branches.py
@@ -32,7 +32,7 @@ def no_cover_nesting_if(x: int, y: int) -> int:
         else:
             return y
     else:
-        return y
+        return 0
 
 def no_cover_nested_if(x: int, y: int) -> int:
     if x > 0:
@@ -41,14 +41,29 @@ def no_cover_nested_if(x: int, y: int) -> int:
         else:
             return y
     else:
-        return y
+        return 0
 
 def no_cover_while(x: int) -> int:
     while x > 0:  # pynguin: no cover
         print(x)
     return x
 
+def no_cover_if_in_while(x: int) -> int:
+    while x > 0:  # pynguin: no cover
+        if x > 0:
+            print(x)
+        else:
+            print(-x)
+    return x
+
 def no_cover_for(x: int) -> int:
     for i in range(x):  # pynguin: no cover
         print(i)
+    return x
+
+def no_cover_for_else(x: int) -> int:
+    for i in range(x):
+        print(i)
+    else:  # pynguin: no cover
+        print(-1)
     return x

--- a/tests/fixtures/instrumentation/covered_branches.py
+++ b/tests/fixtures/instrumentation/covered_branches.py
@@ -17,7 +17,7 @@ def no_cover_elif(x: int, y: int) -> int:
     elif y > 0:  # pynguin: no cover
         return y
     else:
-        return x
+        return 0
 
 def no_cover_else(x: int, y: int) -> int:
     if x > 0:

--- a/tests/fixtures/instrumentation/covered_lines.py
+++ b/tests/fixtures/instrumentation/covered_lines.py
@@ -16,3 +16,50 @@ def no_cover_lines() -> int:
         print(a)  # pynguin: no cover
 
     return 24
+
+def no_cover_try_except(x: float, y: float) -> float:
+    result = -1.0
+    try:
+        result = x / y
+    except ZeroDivisionError:  # pynguin: no cover
+        result = 0.0
+    return result
+
+def no_cover_try_finally(x: float, y: float) -> float:
+    try:
+        result = x / y
+    finally:  # pynguin: no cover
+        result = 0.0
+    return result
+
+def no_cover_try_except_else(x: float, y: float) -> float:
+    result = -1.0
+    try:
+        result = x / y
+    except ZeroDivisionError:
+        result = 0.0
+    else:  # pynguin: no cover
+        result = 1.0
+    return result
+
+def no_cover_try_except_finally(x: float, y: float) -> float:
+    result = -1.0
+    try:
+        result = x / y
+    except ZeroDivisionError:
+        result = 0.0
+    finally:  # pynguin: no cover
+        result = 1.0
+    return result
+
+def no_cover_try_except_else_finally(x: float, y: float) -> float:
+    result = -1.0
+    try:
+        result = x / y
+    except ZeroDivisionError:  # pynguin: no cover
+        result = 0.0
+    else:
+        result = -1.0
+    finally:
+        result = 1.0
+    return result

--- a/tests/instrumentation/test_ast_info.py
+++ b/tests/instrumentation/test_ast_info.py
@@ -237,7 +237,41 @@ def test_ast_info_from_covered_branches(scope_line, expected_lines, expected_bra
     "scope_line, expected_lines",
     [
         # scope_line, dict of line: expected_should_cover
-        (8, {9: True, 10: False, 12: True, 13: True, 14: True, 15: True, 16: False, 18: True}),
+        (
+            8,
+            {9: True, 10: False, 12: True, 13: True, 14: True, 15: True, 16: False, 18: True},
+        ),
+        (
+            20,
+            {21: True, 22: True, 23: True, 24: False, 25: False, 26: True},
+        ),
+        (
+            28,
+            {29: True, 30: True, 31: False, 32: False, 33: True},
+        ),
+        (
+            35,
+            {36: True, 37: True, 38: True, 39: True, 40: True, 41: False, 42: False, 43: True},
+        ),
+        (
+            45,
+            {46: True, 47: True, 48: True, 49: True, 50: True, 51: False, 52: False, 53: True},
+        ),
+        (
+            55,
+            {
+                56: True,
+                57: True,
+                58: True,
+                59: False,
+                60: False,
+                61: True,
+                62: True,
+                63: True,
+                64: True,
+                65: True,
+            },
+        ),
     ],
 )
 def test_ast_info_from_covered_lines(scope_line, expected_lines):
@@ -250,7 +284,7 @@ def test_ast_info_from_covered_lines(scope_line, expected_lines):
 
     assert module_ast_info is not None
     assert not module_ast_info.only_cover_lines
-    assert module_ast_info.no_cover_lines == {10, 16}
+    assert module_ast_info.no_cover_lines == {10, 16, 24, 31, 41, 51, 59}
 
     scope = module_ast_info.get_scope(scope_line)
     assert scope is not None

--- a/tests/instrumentation/test_ast_info.py
+++ b/tests/instrumentation/test_ast_info.py
@@ -145,19 +145,57 @@ def test_ast_info_from_covered_classes(scope_line, expected_should_be_covered):
 
 
 @pytest.mark.parametrize(
-    "scope_line, expected_lines",
+    "scope_line, expected_lines, expected_branches",
     [
-        # scope_line, dict of line: expected_should_cover
-        (8, {9: False, 10: False, 11: True, 12: True}),
-        (14, {15: True, 16: True, 17: False, 18: False, 19: True, 20: True}),
-        (22, {23: True, 24: True, 25: False, 26: False}),
-        (28, {29: False, 30: False, 31: False, 32: False, 33: False, 34: True, 35: True}),
-        (37, {38: True, 39: False, 40: False, 41: True, 42: True, 43: True, 44: True}),
-        (46, {47: False, 48: False, 49: True}),
-        (51, {52: False, 53: False, 54: True}),
+        # scope_line, dict of line: expected_should_cover, dict of line: expected_should_cover
+        (
+            8,
+            {9: False, 10: False, 11: True, 12: True},
+            {9: False, 11: False},
+        ),
+        (
+            14,
+            {15: True, 16: True, 17: False, 18: False, 19: True, 20: True},
+            {15: False, 17: False, 19: False},
+        ),
+        (
+            22,
+            {23: True, 24: True, 25: False, 26: False},
+            {23: False, 25: False},
+        ),
+        (
+            28,
+            {29: False, 30: False, 31: False, 32: False, 33: False, 34: True, 35: True},
+            {29: False, 30: True, 32: True, 34: False},
+        ),
+        (
+            37,
+            {38: True, 39: False, 40: False, 41: True, 42: True, 43: True, 44: True},
+            {38: True, 39: False, 41: False, 43: True},
+        ),
+        (
+            46,
+            {47: False, 48: False, 49: True},
+            {47: False},
+        ),
+        (
+            51,
+            {52: False, 53: False, 54: False, 55: False, 56: False, 57: True},
+            {52: False, 53: True, 55: True},
+        ),
+        (
+            59,
+            {60: False, 61: False, 62: True},
+            {60: False},
+        ),
+        (
+            64,
+            {65: True, 66: True, 67: False, 68: False, 69: True},
+            {65: False, 67: False},
+        ),
     ],
 )
-def test_ast_info_from_covered_branches(scope_line, expected_lines):
+def test_ast_info_from_covered_branches(scope_line, expected_lines, expected_branches):
     module_name = "tests.fixtures.instrumentation.covered_branches"
     module_ast_info = ModuleAstInfo.from_path(
         get_module_path(module_name),
@@ -167,11 +205,14 @@ def test_ast_info_from_covered_branches(scope_line, expected_lines):
 
     assert module_ast_info is not None
     assert not module_ast_info.only_cover_lines
-    assert module_ast_info.no_cover_lines == {9, 17, 25, 29, 39, 47, 52}
+    assert module_ast_info.no_cover_lines == {9, 17, 25, 29, 39, 47, 52, 60, 67}
 
     scope = module_ast_info.get_scope(scope_line)
     assert scope is not None
     assert scope.should_be_covered()
+
+    for line, expected in expected_branches.items():
+        assert scope.should_cover_conditional_statement(line) is expected
 
     for line, expected in expected_lines.items():
         assert scope.should_cover_line(line) is expected

--- a/tests/instrumentation/test_ast_info.py
+++ b/tests/instrumentation/test_ast_info.py
@@ -193,6 +193,21 @@ def test_ast_info_from_covered_classes(scope_line, expected_should_be_covered):
             {65: True, 66: True, 67: False, 68: False, 69: True},
             {65: False, 67: False},
         ),
+        (
+            71,
+            {72: False, 73: False, 74: False, 75: False, 76: False, 77: True},
+            {73: False, 75: False},
+        ),
+        (
+            79,
+            {80: True, 81: False, 82: False, 83: True, 84: True, 85: True, 86: True},
+            {81: False, 83: True, 85: True},
+        ),
+        (
+            88,
+            {89: True, 90: True, 91: False, 92: False, 93: True, 94: True, 95: True},
+            {91: False, 93: True},
+        ),
     ],
 )
 def test_ast_info_from_covered_branches(scope_line, expected_lines, expected_branches):
@@ -205,7 +220,7 @@ def test_ast_info_from_covered_branches(scope_line, expected_lines, expected_bra
 
     assert module_ast_info is not None
     assert not module_ast_info.only_cover_lines
-    assert module_ast_info.no_cover_lines == {9, 17, 25, 29, 39, 47, 53, 60, 67}
+    assert module_ast_info.no_cover_lines == {9, 17, 25, 29, 39, 47, 53, 60, 67, 72, 81, 91}
 
     scope = module_ast_info.get_scope(scope_line)
     assert scope is not None

--- a/tests/instrumentation/test_ast_info.py
+++ b/tests/instrumentation/test_ast_info.py
@@ -156,7 +156,7 @@ def test_ast_info_from_covered_classes(scope_line, expected_should_be_covered):
         (
             14,
             {15: True, 16: True, 17: False, 18: False, 19: True, 20: True},
-            {15: False, 17: False, 19: False},
+            {15: True, 17: False, 19: False},
         ),
         (
             22,
@@ -180,8 +180,8 @@ def test_ast_info_from_covered_classes(scope_line, expected_should_be_covered):
         ),
         (
             51,
-            {52: False, 53: False, 54: False, 55: False, 56: False, 57: True},
-            {52: False, 53: False, 55: False},
+            {52: True, 53: False, 54: False, 55: True, 56: True, 57: True},
+            {52: True, 53: False, 55: False},
         ),
         (
             59,
@@ -205,7 +205,7 @@ def test_ast_info_from_covered_branches(scope_line, expected_lines, expected_bra
 
     assert module_ast_info is not None
     assert not module_ast_info.only_cover_lines
-    assert module_ast_info.no_cover_lines == {9, 17, 25, 29, 39, 47, 52, 60, 67}
+    assert module_ast_info.no_cover_lines == {9, 17, 25, 29, 39, 47, 53, 60, 67}
 
     scope = module_ast_info.get_scope(scope_line)
     assert scope is not None

--- a/tests/instrumentation/test_ast_info.py
+++ b/tests/instrumentation/test_ast_info.py
@@ -166,7 +166,7 @@ def test_ast_info_from_covered_classes(scope_line, expected_should_be_covered):
         (
             28,
             {29: False, 30: False, 31: False, 32: False, 33: False, 34: True, 35: True},
-            {29: False, 30: True, 32: True, 34: False},
+            {29: False, 30: False, 32: False, 34: False},
         ),
         (
             37,
@@ -181,7 +181,7 @@ def test_ast_info_from_covered_classes(scope_line, expected_should_be_covered):
         (
             51,
             {52: False, 53: False, 54: False, 55: False, 56: False, 57: True},
-            {52: False, 53: True, 55: True},
+            {52: False, 53: False, 55: False},
         ),
         (
             59,

--- a/tests/instrumentation/test_controldependencegraph.py
+++ b/tests/instrumentation/test_controldependencegraph.py
@@ -298,6 +298,34 @@ if sys.version_info >= (3, 14):
         "'print(-x)' (4) and 'while (x > 0)' (1) depend on 'while (x > 0)' (1) and"
         "while initialisation (0), 'while (x > 0)' (1) and 'return x' (5) depend on root"
     )
+    no_cover_case_only_catchall_values = {
+        (ArtificialNode.AUGMENTED_ENTRY, 2),
+        (ArtificialNode.AUGMENTED_ENTRY, 3),
+    }
+    no_cover_case_only_catchall_id = "'a = 0' (2) and 'return str(a)' (3) depend on root"
+elif sys.version_info >= (3, 13):
+    no_cover_while_values = {
+        (ArtificialNode.AUGMENTED_ENTRY, 3),
+    }
+    no_cover_while_id = "'return x' (3) depends on root"
+    no_cover_if_in_while_values = {
+        (ArtificialNode.AUGMENTED_ENTRY, 0),
+        (0, 3),
+        (0, 4),
+        (4, 3),
+        (4, 4),
+        (4, 5),
+        (ArtificialNode.AUGMENTED_ENTRY, 6),
+    }
+    no_cover_if_in_while_id = (
+        "'print(-x)' (3) and 'while (x > 0)' (4) depend on 'while (x > 0)' (0, 4) and"
+        "'while (x > 0)' (0) and 'return x' (6) depend on root"
+    )
+    no_cover_case_only_catchall_values = {
+        (ArtificialNode.AUGMENTED_ENTRY, 2),
+        (ArtificialNode.AUGMENTED_ENTRY, 3),
+    }
+    no_cover_case_only_catchall_id = "'a = 0' (2) and 'return str(a)' (3) depend on root"
 elif sys.version_info >= (3, 12):
     no_cover_while_values = {
         (ArtificialNode.AUGMENTED_ENTRY, 3),
@@ -316,6 +344,33 @@ elif sys.version_info >= (3, 12):
         "'print(-x)' (3) and 'while (x > 0)' (4) depend on 'while (x > 0)' (0, 4) and"
         "'while (x > 0)' (0) and 'return x' (6) depend on root"
     )
+    no_cover_case_only_catchall_values = {
+        (ArtificialNode.AUGMENTED_ENTRY, 1),
+        (ArtificialNode.AUGMENTED_ENTRY, 2),
+    }
+    no_cover_case_only_catchall_id = "'a = 0' (1) and 'return str(a)' (2) depend on root"
+elif sys.version_info >= (3, 11):
+    no_cover_while_values = {
+        (ArtificialNode.AUGMENTED_ENTRY, 2),
+    }
+    no_cover_while_id = "'return x' (2) depends on root"
+    no_cover_if_in_while_values = {
+        (ArtificialNode.AUGMENTED_ENTRY, 0),
+        (0, 3),
+        (0, 4),
+        (4, 3),
+        (4, 4),
+        (ArtificialNode.AUGMENTED_ENTRY, 5),
+    }
+    no_cover_if_in_while_id = (
+        "'print(-x)' (3) and 'while (x > 0)' (4) depend on 'while (x > 0)' (0, 4) and"
+        "'while (x > 0)' (0) and 'return x' (5) depend on root"
+    )
+    no_cover_case_only_catchall_values = {
+        (ArtificialNode.AUGMENTED_ENTRY, 2),
+        (ArtificialNode.AUGMENTED_ENTRY, 3),
+    }
+    no_cover_case_only_catchall_id = "'a = 0' (2) and 'return str(a)' (3) depend on root"
 else:
     no_cover_while_values = {
         (ArtificialNode.AUGMENTED_ENTRY, 2),
@@ -333,6 +388,11 @@ else:
         "'print(-x)' (3) and 'while (x > 0)' (4) depend on 'while (x > 0)' (0, 4) and"
         "'while (x > 0)' (0) and 'return x' (5) depend on root"
     )
+    no_cover_case_only_catchall_values = {
+        (ArtificialNode.AUGMENTED_ENTRY, 1),
+        (ArtificialNode.AUGMENTED_ENTRY, 2),
+    }
+    no_cover_case_only_catchall_id = "'a = 0' (1) and 'return str(a)' (2) depend on root"
 
 
 @pytest.mark.parametrize(
@@ -403,6 +463,28 @@ else:
                 (ArtificialNode.AUGMENTED_ENTRY, 3),
             },
             id="'print(i)' (2), 'return x' (3) depend on root",
+        ),
+        pytest.param(
+            "no_cover_match",
+            {
+                (ArtificialNode.AUGMENTED_ENTRY, 3),
+            },
+            id="'return str(a) * 2' (3) depends on root",
+        ),
+        pytest.param(
+            "no_cover_case",
+            {
+                (ArtificialNode.AUGMENTED_ENTRY, 2),
+                (2, 3),
+                (2, 4),
+            },
+            id="'return 2' (3) and 'return 0' (4) depend on 'case 2' (2) and "
+            "'case 2' (2) depends on root",
+        ),
+        pytest.param(
+            "no_cover_case_only_catchall",
+            no_cover_case_only_catchall_values,
+            id=no_cover_case_only_catchall_id,
         ),
     ],
 )

--- a/tests/instrumentation/test_controldependencegraph.py
+++ b/tests/instrumentation/test_controldependencegraph.py
@@ -286,30 +286,53 @@ if sys.version_info >= (3, 14):
         (ArtificialNode.AUGMENTED_ENTRY, 0),
         (ArtificialNode.AUGMENTED_ENTRY, 3),
     }
-    no_cover_while_id = "while initialisation (0) and 'return x' (3) depend on root only"
+    no_cover_while_id = "while initialisation (0) and 'return x' (3) depend on root"
     no_cover_if_in_while_values = {
         (ArtificialNode.AUGMENTED_ENTRY, 0),
+        (ArtificialNode.AUGMENTED_ENTRY, 1),
+        (1, 1),
+        (1, 4),
         (ArtificialNode.AUGMENTED_ENTRY, 5),
     }
-    no_cover_if_in_while_id = "while initialisation (0) and 'return x' (5) depend on root only"
+    no_cover_if_in_while_id = (
+        "'print(-x)' (4) and 'while (x > 0)' (1) depend on 'while (x > 0)' (1) and"
+        "while initialisation (0), 'while (x > 0)' (1) and 'return x' (5) depend on root"
+    )
 elif sys.version_info >= (3, 12):
     no_cover_while_values = {
         (ArtificialNode.AUGMENTED_ENTRY, 3),
     }
-    no_cover_while_id = "'return x' (3) depends on root only"
+    no_cover_while_id = "'return x' (3) depends on root"
     no_cover_if_in_while_values = {
+        (ArtificialNode.AUGMENTED_ENTRY, 0),
+        (0, 3),
+        (0, 4),
+        (4, 3),
+        (4, 4),
+        (4, 5),
         (ArtificialNode.AUGMENTED_ENTRY, 6),
     }
-    no_cover_if_in_while_id = "'return x' (6) depends on root only"
+    no_cover_if_in_while_id = (
+        "'print(-x)' (3) and 'while (x > 0)' (4) depend on 'while (x > 0)' (0, 4) and"
+        "'while (x > 0)' (0) and 'return x' (6) depend on root"
+    )
 else:
     no_cover_while_values = {
         (ArtificialNode.AUGMENTED_ENTRY, 2),
     }
-    no_cover_while_id = "'return x' (2) depends on root only"
+    no_cover_while_id = "'return x' (2) depends on root"
     no_cover_if_in_while_values = {
+        (ArtificialNode.AUGMENTED_ENTRY, 0),
+        (0, 3),
+        (0, 4),
+        (4, 3),
+        (4, 4),
         (ArtificialNode.AUGMENTED_ENTRY, 5),
     }
-    no_cover_if_in_while_id = "'return x' (5) depends on root only"
+    no_cover_if_in_while_id = (
+        "'print(-x)' (3) and 'while (x > 0)' (4) depend on 'while (x > 0)' (0, 4) and"
+        "'while (x > 0)' (0) and 'return x' (5) depend on root"
+    )
 
 
 @pytest.mark.parametrize(
@@ -320,29 +343,31 @@ else:
             {
                 (ArtificialNode.AUGMENTED_ENTRY, 2),
             },
-            id="'return y' (2) depends on root only",
+            id="'return y' (2) depends on root",
         ),
         pytest.param(
             "no_cover_elif",
             {
-                (ArtificialNode.AUGMENTED_ENTRY, 1),
-                (ArtificialNode.AUGMENTED_ENTRY, 4),
+                (ArtificialNode.AUGMENTED_ENTRY, 0),
+                (0, 1),
+                (0, 4),
             },
-            id="'return x' (1) and 'return 0' (4) depend on root only",
+            id="'return x' (1) and 'return 0' (4) depend on 'if x > 0' (0) and "
+            "'if x > 0' (0) depends on root",
         ),
         pytest.param(
             "no_cover_else",
             {
                 (ArtificialNode.AUGMENTED_ENTRY, 1),
             },
-            id="'return x' (1) depends on root only",
+            id="'return x' (1) depends on root",
         ),
         pytest.param(
             "no_cover_nesting_if",
             {
                 (ArtificialNode.AUGMENTED_ENTRY, 4),
             },
-            id="'return 0' (4) depends on root only",
+            id="'return 0' (4) depends on root",
         ),
         pytest.param(
             "no_cover_nested_if",
@@ -352,7 +377,7 @@ else:
                 (0, 4),
             },
             id="'return y' (3) depend on 'if x > 0' (0) and "
-            "'if x > 0' (0) and 'return 0' (4) depend on root only",
+            "'if x > 0' (0) and 'return 0' (4) depend on root",
         ),
         pytest.param(
             "no_cover_while",
@@ -369,7 +394,7 @@ else:
             {
                 (ArtificialNode.AUGMENTED_ENTRY, 3),
             },
-            id="'return x' (3) depends on root only",
+            id="'return x' (3) depends on root",
         ),
         pytest.param(
             "no_cover_for_else",
@@ -377,7 +402,7 @@ else:
                 (ArtificialNode.AUGMENTED_ENTRY, 2),
                 (ArtificialNode.AUGMENTED_ENTRY, 3),
             },
-            id="'print(i)' (2), 'print(-1); return x' (3) depend on root only",
+            id="'print(i)' (2), 'return x' (3) depend on root",
         ),
     ],
 )

--- a/tests/instrumentation/test_controldependencegraph.py
+++ b/tests/instrumentation/test_controldependencegraph.py
@@ -284,54 +284,32 @@ def covered_branches_module():
 if sys.version_info >= (3, 14):
     no_cover_while_values = {
         (ArtificialNode.AUGMENTED_ENTRY, 0),
-        (ArtificialNode.AUGMENTED_ENTRY, 2),
         (ArtificialNode.AUGMENTED_ENTRY, 3),
     }
-    no_cover_while_id = (
-        "while initialisation (0), 'print(x)' (2) and 'return x' (3) depend on root only"
-    )
+    no_cover_while_id = "while initialisation (0) and 'return x' (3) depend on root only"
     no_cover_if_in_while_values = {
         (ArtificialNode.AUGMENTED_ENTRY, 0),
-        (ArtificialNode.AUGMENTED_ENTRY, 3),
-        (ArtificialNode.AUGMENTED_ENTRY, 4),
         (ArtificialNode.AUGMENTED_ENTRY, 5),
     }
-    no_cover_if_in_while_id = (
-        "while initialisation (0), 'print(x)' (3), 'print(-x)' (4) and "
-        "'return x' (5) depend on root only"
-    )
+    no_cover_if_in_while_id = "while initialisation (0) and 'return x' (5) depend on root only"
 elif sys.version_info >= (3, 12):
     no_cover_while_values = {
-        # 'print(x)' (1) is not included as its bytecode is included in the loop structure
-        # and is therefore removed when the loop is removed. It is not a problem as
-        # we only care about predicates here and there are none in the while loop.
         (ArtificialNode.AUGMENTED_ENTRY, 3),
     }
     no_cover_while_id = "'return x' (3) depends on root only"
     no_cover_if_in_while_values = {
-        (ArtificialNode.AUGMENTED_ENTRY, 2),
-        (ArtificialNode.AUGMENTED_ENTRY, 3),
         (ArtificialNode.AUGMENTED_ENTRY, 6),
     }
-    no_cover_if_in_while_id = (
-        "'print(x)' (2), 'print(-x)' (3) and 'return x' (6) depend on root only"
-    )
+    no_cover_if_in_while_id = "'return x' (6) depends on root only"
 else:
     no_cover_while_values = {
-        # 'print(x)' (1) is not included as its bytecode is included in the loop structure
-        # and is therefore removed when the loop is removed. It is not a problem as
-        # we only care about predicates here and there are none in the while loop.
         (ArtificialNode.AUGMENTED_ENTRY, 2),
     }
     no_cover_while_id = "'return x' (2) depends on root only"
     no_cover_if_in_while_values = {
-        (ArtificialNode.AUGMENTED_ENTRY, 2),
-        (ArtificialNode.AUGMENTED_ENTRY, 3),
         (ArtificialNode.AUGMENTED_ENTRY, 5),
     }
-    no_cover_if_in_while_id = (
-        "'print(x)' (2), 'print(-x)' (3) and 'return x' (5) depend on root only"
-    )
+    no_cover_if_in_while_id = "'return x' (5) depends on root only"
 
 
 @pytest.mark.parametrize(
@@ -340,47 +318,41 @@ else:
         pytest.param(
             "no_cover_if",
             {
-                (ArtificialNode.AUGMENTED_ENTRY, 1),
                 (ArtificialNode.AUGMENTED_ENTRY, 2),
             },
-            id="'return x' (1) and 'return y' (2) depend on root only",
+            id="'return y' (2) depends on root only",
         ),
         pytest.param(
             "no_cover_elif",
             {
                 (ArtificialNode.AUGMENTED_ENTRY, 1),
-                (ArtificialNode.AUGMENTED_ENTRY, 3),
                 (ArtificialNode.AUGMENTED_ENTRY, 4),
             },
-            id="'return x' (1), 'return y' (3) and 'return x' (4) depend on root only",
+            id="'return x' (1) and 'return 0' (4) depend on root only",
         ),
         pytest.param(
             "no_cover_else",
             {
                 (ArtificialNode.AUGMENTED_ENTRY, 1),
-                (ArtificialNode.AUGMENTED_ENTRY, 2),
             },
-            id="'return x' (1) and 'return y' (2) depend on root only",
+            id="'return x' (1) depends on root only",
         ),
         pytest.param(
             "no_cover_nesting_if",
             {
-                (ArtificialNode.AUGMENTED_ENTRY, 2),
-                (ArtificialNode.AUGMENTED_ENTRY, 3),
                 (ArtificialNode.AUGMENTED_ENTRY, 4),
             },
-            id="'return x' (2), 'return y' (3) and 'return 0' (4) depend on root only",
+            id="'return 0' (4) depends on root only",
         ),
         pytest.param(
             "no_cover_nested_if",
             {
                 (ArtificialNode.AUGMENTED_ENTRY, 0),
-                (0, 2),
                 (0, 3),
                 (0, 4),
             },
-            id="'return x' (2), 'return y' (3) and 'return 0' (4) depend on 'if x > 0' (0) and "
-            "'return 0' (4) depend on root only",
+            id="'return y' (3) depend on 'if x > 0' (0) and "
+            "'if x > 0' (0) and 'return 0' (4) depend on root only",
         ),
         pytest.param(
             "no_cover_while",
@@ -395,10 +367,9 @@ else:
         pytest.param(
             "no_cover_for",
             {
-                (ArtificialNode.AUGMENTED_ENTRY, 2),
                 (ArtificialNode.AUGMENTED_ENTRY, 3),
             },
-            id="'print(i)' (2) and 'return x' (3) depend on root only",
+            id="'return x' (3) depends on root only",
         ),
         pytest.param(
             "no_cover_for_else",

--- a/tests/instrumentation/test_controldependencegraph.py
+++ b/tests/instrumentation/test_controldependencegraph.py
@@ -292,14 +292,13 @@ if sys.version_info >= (3, 14):
     )
     no_cover_if_in_while_values = {
         (ArtificialNode.AUGMENTED_ENTRY, 0),
-        (ArtificialNode.AUGMENTED_ENTRY, 2),
-        (2, 3),
-        (2, 4),
+        (ArtificialNode.AUGMENTED_ENTRY, 3),
+        (ArtificialNode.AUGMENTED_ENTRY, 4),
         (ArtificialNode.AUGMENTED_ENTRY, 5),
     }
     no_cover_if_in_while_id = (
-        "'print(x)' (2) and 'print(-x)' (3) depend on 'if x > 0' (1) and "
-        "while initialisation (0), 'if x > 0' (1) and 'return x' (5) depend on root only"
+        "while initialisation (0), 'print(x)' (3), 'print(-x)' (4) and "
+        "'return x' (5) depend on root only"
     )
 elif sys.version_info >= (3, 12):
     no_cover_while_values = {
@@ -310,14 +309,12 @@ elif sys.version_info >= (3, 12):
     }
     no_cover_while_id = "'return x' (3) depends on root only"
     no_cover_if_in_while_values = {
-        (ArtificialNode.AUGMENTED_ENTRY, 1),
-        (1, 2),
-        (1, 3),
+        (ArtificialNode.AUGMENTED_ENTRY, 2),
+        (ArtificialNode.AUGMENTED_ENTRY, 3),
         (ArtificialNode.AUGMENTED_ENTRY, 6),
     }
     no_cover_if_in_while_id = (
-        "'print(x)' (2) and 'print(-x)' (3) depend on 'if x > 0' (1) and "
-        "'if x > 0' (1) and 'return x' (6) depend on root only"
+        "'print(x)' (2), 'print(-x)' (3) and 'return x' (6) depend on root only"
     )
 else:
     no_cover_while_values = {
@@ -328,14 +325,12 @@ else:
     }
     no_cover_while_id = "'return x' (2) depends on root only"
     no_cover_if_in_while_values = {
-        (ArtificialNode.AUGMENTED_ENTRY, 1),
-        (1, 2),
-        (1, 3),
+        (ArtificialNode.AUGMENTED_ENTRY, 2),
+        (ArtificialNode.AUGMENTED_ENTRY, 3),
         (ArtificialNode.AUGMENTED_ENTRY, 5),
     }
     no_cover_if_in_while_id = (
-        "'print(x)' (2) and 'print(-x)' (3) depend on 'if x > 0' (1) and "
-        "'if x > 0' (1) and 'return x' (5) depend on root only"
+        "'print(x)' (2), 'print(-x)' (3) and 'return x' (5) depend on root only"
     )
 
 
@@ -370,13 +365,11 @@ else:
         pytest.param(
             "no_cover_nesting_if",
             {
-                (ArtificialNode.AUGMENTED_ENTRY, 1),
-                (1, 2),
-                (1, 3),
+                (ArtificialNode.AUGMENTED_ENTRY, 2),
+                (ArtificialNode.AUGMENTED_ENTRY, 3),
                 (ArtificialNode.AUGMENTED_ENTRY, 4),
             },
-            id="'return x' (2) and 'return y' (3) depend on 'if x > 0' (1) and "
-            "'if x > 0' (1) and 'return 0' (4) depend on root only",
+            id="'return x' (2), 'return y' (3) and 'return 0' (4) depend on root only",
         ),
         pytest.param(
             "no_cover_nested_if",


### PR DESCRIPTION
Hi,

This PR fixes some bugs introduced by #115.

The biggest bug came from the fact that DYNAMOSA's `BranchGoal`s could not be calculated properly because the `pragma: no cover` annotations in the code could remove some predicates from the subject properties, but not from the CDGs. There were several ways to fix the problem, but the one that made the most sense to me was also to smartly remove the nodes affected by the `pragma: no cover` annotations in the CDG.

Besides that, it is mainly some fixes to make Pynguin more consistent with how coverage.py handles the `pragma: no cover` annotations and the addition of tests.