### PR TITLE
Fix "tracing aborted" in coverage report

### DIFF
--- a/src/pynguin/ga/algorithms/llmosalgorithm.py
+++ b/src/pynguin/ga/algorithms/llmosalgorithm.py
@@ -174,7 +174,7 @@ class LLMOSAAlgorithm(MOSAAlgorithm):
         # Main logic
         coverage_report: CoverageReport = get_coverage_report(
             solutions_test_suite,
-            self.executor,  # type:ignore[arg-type]
+            self.executor.subject_properties,
             set(config.configuration.statistics_output.coverage_metrics),
         )
         line_annotations: list[LineAnnotation] = coverage_report.line_annotations

--- a/src/pynguin/generator.py
+++ b/src/pynguin/generator.py
@@ -609,6 +609,8 @@ def _run() -> ReturnCode:  # noqa: C901
         algorithm, executor, generation_result, constant_provider
     )
 
+    executor.subject_properties.instrumentation_tracer.disable()
+
     # Export the generated test suites
     if config.configuration.test_case_output.export_strategy == config.ExportStrategy.PY_TEST:
         try:

--- a/src/pynguin/generator.py
+++ b/src/pynguin/generator.py
@@ -620,7 +620,7 @@ def _run() -> ReturnCode:  # noqa: C901
         try:
             coverage_report = get_coverage_report(
                 generation_result,
-                executor,
+                executor.subject_properties,
                 tracked_metrics,
             )
             render_coverage_report(

--- a/src/pynguin/instrumentation/tracer.py
+++ b/src/pynguin/instrumentation/tracer.py
@@ -1097,10 +1097,10 @@ def _early_return(
 ) -> Callable[Concatenate[ExecutionTracer, _P], None]:
     @wraps(func)
     def wrapper(self: ExecutionTracer, *args: _P.args, **kwargs: _P.kwargs) -> None:
-        self.check()
-
         if self.is_disabled():
             return
+
+        self.check()
 
         func(self, *args, **kwargs)
 

--- a/src/pynguin/testcase/llmlocalsearch.py
+++ b/src/pynguin/testcase/llmlocalsearch.py
@@ -124,7 +124,7 @@ class LLMLocalSearch:
         failing_test = self.chromosome.is_failing()
         self._logger.debug("Starting local search with LLMs at position %d", position)
         metrics = set(config.configuration.statistics_output.coverage_metrics)
-        report = get_coverage_report(self.suite, self.executor, metrics)
+        report = get_coverage_report(self.suite, self.executor.subject_properties, metrics)
 
         stat.add_to_runtime_variable(RuntimeVariable.TotalLocalSearchLLMCalls, 1)
         if failing_test:

--- a/src/pynguin/utils/report.py
+++ b/src/pynguin/utils/report.py
@@ -34,7 +34,7 @@ if typing.TYPE_CHECKING:
 
     import pynguin.ga.testsuitechromosome as tsc
 
-    from pynguin.testcase.execution import TestCaseExecutor
+    from pynguin.instrumentation.tracer import SubjectProperties
 
 
 @dataclasses.dataclass(frozen=True)
@@ -139,14 +139,14 @@ class CoverageReport:
 
 def get_coverage_report(
     suite: tsc.TestSuiteChromosome,
-    executor: TestCaseExecutor,
+    subject_properties: SubjectProperties,
     metrics: set[config.CoverageMetric],
 ) -> CoverageReport:
     """Create a coverage report for the given test suite.
 
     Args:
         suite: The suite for which a coverage report should be generated.
-        executor: The executor
+        subject_properties: The subject properties.
         metrics: In which coverage metrics are we interested?
 
     Returns:
@@ -158,7 +158,6 @@ def get_coverage_report(
         assert result is not None
         results.append(result)
     trace = ff.analyze_results(results)
-    subject_properties = executor.subject_properties
     try:
         source = inspect.getsourcelines(sys.modules[config.configuration.module_name])[0]
     except Exception as e:

--- a/tests/utils/test_report.py
+++ b/tests/utils/test_report.py
@@ -4,7 +4,7 @@
 #
 #  SPDX-License-Identifier: MIT
 #
-# ruff: noqa: E501
+
 import datetime
 import importlib
 import sys
@@ -258,12 +258,11 @@ def test_get_coverage_report(
         with subject_properties.instrumentation_tracer:
             importlib.import_module(test_module)
 
-        executor = MagicMock(subject_properties=subject_properties)
         config.configuration.module_name = test_module
         assert (
             get_coverage_report(
                 test_suite,
-                executor,
+                subject_properties,
                 {config.CoverageMetric.LINE, config.CoverageMetric.BRANCH},
             )
             == sample_report
@@ -483,8 +482,6 @@ def test_get_coverage_report_with_inspect_valueerror():
     test_case.get_last_execution_result.return_value = last_result
     test_suite = MagicMock(test_case_chromosomes=[test_case])
 
-    tracer = MagicMock()
-    executor = MagicMock(tracer=tracer)
     module_name = "test_module"
     config.configuration.module_name = module_name
     mock_module = MagicMock()
@@ -497,15 +494,13 @@ def test_get_coverage_report_with_inspect_valueerror():
     # Use patches to mock all the functions called in get_coverage_report
     with (
         patch("pynguin.ga.computations.analyze_results", return_value=mock_trace),
-        patch.object(executor.tracer, "get_subject_properties", return_value=MagicMock()),
-        patch.object(executor.tracer, "lineids_to_linenos", return_value=OrderedSet()),
         patch.dict(sys.modules, {module_name: mock_module}),
         patch("inspect.getsourcelines", side_effect=value_error),
         pytest.raises(RuntimeError),  # Expect a RuntimeError to be raised
     ):
         get_coverage_report(
             test_suite,
-            executor,
+            SubjectProperties(),
             {config.CoverageMetric.LINE, config.CoverageMetric.BRANCH},
         )
 


### PR DESCRIPTION
Hi,

In some cases, an exception may be raised when the coverage report is created because the tracer is still enabled but considers the current thread to be the wrong thread :

```
[11:05:21] [Info] (pynguin.generator:run_pynguin:136): Stop Pynguin Test Generation…
Traceback (most recent call last):
  File "/usr/local/bin/pynguin", line 8, in <module>
    sys.exit(main())
  File "/usr/local/lib/python3.10/site-packages/pynguin/cli.py", line 213, in main
    return run_pynguin().value
  File "/usr/local/lib/python3.10/site-packages/pynguin/generator.py", line 134, in run_pynguin
    return _run()
  File "/usr/local/lib/python3.10/site-packages/pynguin/generator.py", line 621, in _run
    coverage_report = get_coverage_report(
  File "/usr/local/lib/python3.10/site-packages/pynguin/utils/report.py", line 163, in get_coverage_report
    source = inspect.getsourcelines(sys.modules[config.configuration.module_name])[0]
  File "/usr/local/lib/python3.10/inspect.py", line 1120, in getsourcelines
    object = unwrap(object)
  File "/usr/local/lib/python3.10/inspect.py", line 639, in unwrap
    while _is_wrapper(func):
  File "/usr/local/lib/python3.10/inspect.py", line 630, in _is_wrapper
    return hasattr(f, '__wrapped__')
  File "/usr/local/lib/python3.10/site-packages/numpy/core/fromnumeric.py", line 2, in __getattr__
    from numpy._core import fromnumeric
  File "/usr/local/lib/python3.10/site-packages/pynguin/instrumentation/tracer.py", line 1701, in executed_code_object
    self._tracer.executed_code_object(code_object_id)
  File "/usr/local/lib/python3.10/site-packages/pynguin/instrumentation/tracer.py", line 1100, in wrapper
    self.check()
  File "/usr/local/lib/python3.10/site-packages/pynguin/instrumentation/tracer.py", line 1151, in check
    raise TracingAbortedException(
pynguin.utils.exceptions.TracingAbortedException: The current thread shall not be executed anymore, thus I kill it.
```

To fix the problem, I've disabled the tracer when it is no longer needed and changed the moment when the tracer automatically checks the current thread so that it won't do it if it is disabled. This last change is safe because the "enabled/disabled" status is thread-specific and, therefore, in practice, a thread would have to run a test that takes too long and disable its tracer for this to cause a change. This can happen in practice because, before executing remote observers, the tracer is temporarily disabled, but these observers should only make local changes, so, except for the fact that some observer code might run a little longer in really rare cases, this will have no effect.

I also did some refactoring of the `get_coverage_report` function because it only requires `subject_properties` and not a `TestCaseExecutor`.