### PR TITLE
Add LLDynaMOSA: DynaMOSA with LLM-guided stall recovery

### DIFF
--- a/src/pynguin/configuration.py
+++ b/src/pynguin/configuration.py
@@ -53,6 +53,9 @@ class Algorithm(str, enum.Enum):
     LLMOSA = "LLMOSA"
     """The many-objective sorting algorithm with LLM."""
 
+    LLDYNAMOSA = "LLDYNAMOSA"
+    """The dynamic many-objective sorting algorithm with LLM."""
+
     RANDOM = "RANDOM"
     """A feedback-direct random test generation approach similar to the algorithm
     proposed by Randoop (cf. Pacheco et al. Feedback-directed random test generation.

--- a/src/pynguin/ga/algorithms/lldynamosaalgorithm.py
+++ b/src/pynguin/ga/algorithms/lldynamosaalgorithm.py
@@ -1,0 +1,284 @@
+#  This file is part of Pynguin.
+#
+#  SPDX-FileCopyrightText: 2019–2026 Pynguin Contributors
+#
+#  SPDX-License-Identifier: MIT
+#
+"""Provides the DynaMOSA-LLM test-generation strategy."""
+
+from __future__ import annotations
+
+import inspect
+import logging
+import operator
+import time
+from typing import TYPE_CHECKING, cast
+
+import pynguin.utils.statistics.stats as stat
+from pynguin.ga.algorithms.dynamosaalgorithm import DynaMOSAAlgorithm, _GoalsManager
+from pynguin.ga.algorithms.llmosalgorithm import LLMOSAAlgorithm
+from pynguin.ga.operators.ranking import fast_epsilon_dominance_assignment
+from pynguin.utils.statistics.runtimevariable import RuntimeVariable
+
+if TYPE_CHECKING:
+    import pynguin.ga.coveragegoals as bg
+    import pynguin.ga.testcasechromosome as tcc
+    import pynguin.ga.testsuitechromosome as tsc
+
+import pynguin.configuration as config
+from pynguin.utils.generic.genericaccessibleobject import (
+    GenericCallableAccessibleObject,
+)
+from pynguin.utils.report import CoverageReport, LineAnnotation, get_coverage_report
+
+
+class LLDynaMOSAAlgorithm(LLMOSAAlgorithm, DynaMOSAAlgorithm):
+    """Implements DynaMOSA with LLM-guided stall recovery.
+
+    Extends both LLMOSAAlgorithm and DynaMOSAAlgorithm so the parts of the LLM
+    intervention that don't depend on target selection (init, budget guard, callable
+    diagnosis, population seeding, breeding) are inherited from LLMOSAAlgorithm; only
+    `generate_tests`, `_target_initial_uncovered_goals`, `_eligible_gaos_for_targeting`,
+    and `target_uncovered_callables` are overridden here, since those are the ones
+    that depend on DynaMOSA's dynamic target set.
+    """
+
+    _logger = logging.getLogger(__name__)
+
+    def _target_initial_uncovered_goals(self) -> None:
+        """Performs an LLM intervention to improve coverage before search iteration."""
+        coverage_before = self.create_test_suite(self._archive.solutions).get_coverage()
+
+        if (
+            config.configuration.large_language_model.call_llm_for_uncovered_targets
+            and coverage_before < 1.0
+        ):
+            self._logger.info("Coverage before LLM call: %5f", coverage_before)
+            stat.track_output_variable(RuntimeVariable.CoverageBeforeLLMCall, coverage_before)
+
+            llm_chromosomes = self.target_uncovered_callables()
+            self._population += llm_chromosomes
+            # DynaMOSA's UpdateTargets, not archive.update(): also unlocks any goals
+            # whose parent these chromosomes just covered.
+            self._goals_manager.update(self._population)
+
+            coverage_after = self.create_test_suite(self._archive.solutions).get_coverage()
+            self._logger.info("Coverage after LLM call: %5f", coverage_after)
+            stat.track_output_variable(RuntimeVariable.CoverageAfterLLMCall, coverage_after)
+
+    def generate_tests(self) -> tsc.TestSuiteChromosome:  # noqa: D102
+        self.before_search_start()
+        self._goals_manager = _GoalsManager(
+            self._test_case_fitness_functions,  # type: ignore[arg-type]
+            self._archive,
+            self.executor.subject_properties,
+        )
+        self._number_of_goals = len(self._test_case_fitness_functions)
+        stat.set_output_variable_for_runtime_variable(RuntimeVariable.Goals, self._number_of_goals)
+
+        self._population = self._get_random_population()
+        self._goals_manager.update(self._population)
+
+        self._target_initial_uncovered_goals()
+
+        # Calculate dominance ranks and crowding distance
+        fronts = self._ranking_function.compute_ranking_assignment(
+            self._population, self._goals_manager.current_goals
+        )
+        for i in range(fronts.get_number_of_sub_fronts()):
+            fast_epsilon_dominance_assignment(
+                fronts.get_sub_front(i), self._goals_manager.current_goals
+            )
+
+        self.before_first_search_iteration(self.create_test_suite(self._archive.solutions))
+
+        llm_config = config.configuration.large_language_model
+        last_length_of_covered_goals = len(self._archive.covered_goals)
+        plateau_counter = 0
+        max_plateau_len = llm_config.max_plateau_len
+        last_gain_time = time.time()
+        while self.resources_left() and len(self._archive.uncovered_goals) > 0:
+            if llm_config.call_llm_on_stall_detection:
+                current_covered = len(self._archive.covered_goals)
+                if current_covered != last_length_of_covered_goals:
+                    plateau_counter = 0
+                    last_gain_time = time.time()
+                else:
+                    plateau_counter += 1
+                last_length_of_covered_goals = current_covered
+
+                if llm_config.stall_detection_window_seconds > 0:
+                    stalled = (
+                        time.time() - last_gain_time >= llm_config.stall_detection_window_seconds
+                    )
+                else:
+                    stalled = plateau_counter > max_plateau_len
+
+                if stalled:
+                    self._maybe_intervene_on_stall()
+                    # Reset stall tracking after a firing (or a suppressed attempt) so
+                    # we wait for a fresh plateau before querying again.
+                    plateau_counter = 0
+                    last_gain_time = time.time()
+                    if llm_config.stall_detection_window_seconds <= 0:
+                        max_plateau_len *= 2
+            self.evolve()
+            if config.configuration.local_search.local_search:
+                self.local_search()
+            self.after_search_iteration(self.create_test_suite(self._archive.solutions))
+
+        self.after_search_finish()
+        return self.create_test_suite(
+            self._archive.solutions
+            if len(self._archive.solutions) > 0
+            else self._get_best_individuals()
+        )
+
+    def _eligible_gaos_for_targeting(self) -> set[GenericCallableAccessibleObject]:
+        """Restricts LLM targeting to callables backing a currently-active goal.
+
+        Unlike MOSA, DynaMOSA only activates a target once its control-dependency
+        parent is covered, so this maps each goal in ``current_goals`` back to its
+        owning callable (via ``code_object_id`` -> ``co_firstlineno``, matched
+        against each callable's source start line) rather than considering every
+        callable under test.
+
+        Returns:
+            The subset of `self.test_cluster.accessible_objects_under_test` that owns
+            at least one currently-active goal.
+        """
+        subject_properties = self.executor.subject_properties
+        active_first_lines: set[int] = set()
+        for fitness in self._goals_manager.current_goals:
+            # current_goals is typed as OrderedSet[FitnessFunction] by _GoalsManager
+            # itself, but is always populated with BranchCoverageTestFitness.
+            branch_fitness = cast("bg.BranchCoverageTestFitness", fitness)
+            code_object_meta = subject_properties.existing_code_objects.get(
+                branch_fitness.goal.code_object_id
+            )
+            if code_object_meta is not None:
+                active_first_lines.add(code_object_meta.code_object.co_firstlineno)
+
+        eligible: set[GenericCallableAccessibleObject] = set()
+        for gao in self.test_cluster.accessible_objects_under_test:
+            if not isinstance(gao, GenericCallableAccessibleObject):
+                continue
+            try:
+                _, start_line = inspect.getsourcelines(gao.callable)
+            except (TypeError, OSError):
+                continue
+            if start_line in active_first_lines:
+                eligible.add(gao)
+        return eligible
+
+    def target_uncovered_callables(self) -> list[tcc.TestCaseChromosome]:
+        """Identifies the highest-priority uncovered target, queries an LLM.
+
+         and processes the result into a list of test case chromosomes.
+
+        Returns:
+            A list of `TestCaseChromosome` objects derived from the LLM query result.
+        """
+        solutions_test_suite = self.create_test_suite(self._archive.solutions)
+
+        def coverage_in_range(start_line: int, end_line: int) -> tuple[int, int]:
+            """Calculate the total and covered coverage points for a given line range.
+
+            Args:
+                start_line: The first line in the range, inclusive.
+                end_line: The last line in the range, inclusive.
+
+            Returns:
+                A tuple of (covered points, total points).
+            """
+            total_coverage_points = 0
+            covered_coverage_points = 0
+            for line_annot in line_annotations:
+                if start_line <= line_annot.line_no <= end_line:
+                    total_coverage_points += line_annot.total.existing
+                    covered_coverage_points += line_annot.total.covered
+            return covered_coverage_points, total_coverage_points
+
+        def calculate_gao_coverage_map() -> dict[GenericCallableAccessibleObject, float]:
+            """Calculate the coverage ratio for each eligible callable.
+
+            Returns:
+                A dictionary mapping eligible accessible objects to their coverage
+                ratios.
+            """
+            gao_coverage = {}
+            for gao in self._eligible_gaos_for_targeting():
+                try:
+                    source_lines, start_line = inspect.getsourcelines(gao.callable)
+                    end_line = start_line + len(source_lines) - 1
+                    covered, total = coverage_in_range(start_line, end_line)
+                    coverage_ratio = covered / total if total > 0 else 0
+                except (TypeError, OSError):
+                    coverage_ratio = 0
+                gao_coverage[gao] = coverage_ratio
+            return gao_coverage
+
+        def filter_gao_by_coverage(
+            gao_coverage: dict[GenericCallableAccessibleObject, float],
+        ) -> dict[GenericCallableAccessibleObject, float]:
+            """Filter GenericCallableAccessibleObjects by their coverage ratio.
+
+            Args:
+                gao_coverage: A dictionary of objects and their coverage ratios.
+
+            Returns:
+                A filtered dictionary of objects with coverage below the threshold.
+            """
+            return {
+                gao: coverage
+                for gao, coverage in sorted(gao_coverage.items(), key=operator.itemgetter(1))
+                if coverage < config.configuration.large_language_model.coverage_threshold
+            }
+
+        def select_highest_priority_target(
+            gao_coverage: dict[GenericCallableAccessibleObject, float],
+        ) -> dict[GenericCallableAccessibleObject, float]:
+            """Narrows the query to a single target, priority = 1 - coverage.
+
+            One target per query, deterministically the least-covered callable into one prompt.
+
+            Args:
+                gao_coverage: Coverage-threshold-filtered callables to choose from.
+
+            Returns:
+                A single-entry dict with just the highest-priority target, or an
+                empty dict if ``gao_coverage`` was empty.
+            """
+            if not gao_coverage:
+                return gao_coverage
+            target_gao = min(gao_coverage, key=lambda gao: gao_coverage[gao])
+            return {target_gao: gao_coverage[target_gao]}
+
+        # Main logic
+        coverage_report: CoverageReport = get_coverage_report(
+            solutions_test_suite,
+            self.executor.subject_properties,
+            set(config.configuration.statistics_output.coverage_metrics),
+        )
+        line_annotations: list[LineAnnotation] = coverage_report.line_annotations
+
+        gao_coverage_map = calculate_gao_coverage_map()
+        filtered_gao_coverage_map = filter_gao_by_coverage(gao_coverage_map)
+        targeted_gao_coverage_map = select_highest_priority_target(filtered_gao_coverage_map)
+
+        diagnostics = {
+            gao: self._diagnose_callable(gao, line_annotations) for gao in targeted_gao_coverage_map
+        }
+        diagnostics = {gao: hint for gao, hint in diagnostics.items() if hint}
+
+        llm_query_results = self.model.call_llm_for_uncovered_targets(
+            targeted_gao_coverage_map, diagnostics
+        )
+
+        return self.model.llm_test_case_handler.get_test_case_chromosomes_from_llm_results(
+            llm_query_results=llm_query_results,
+            test_cluster=self.test_cluster,
+            test_factory=self._test_factory,
+            fitness_functions=self._test_case_fitness_functions,
+            coverage_functions=self._test_suite_coverage_functions,
+        )

--- a/src/pynguin/ga/generationalgorithmfactory.py
+++ b/src/pynguin/ga/generationalgorithmfactory.py
@@ -34,6 +34,7 @@ from pynguin.analyses.constants import ConstantProvider, EmptyConstantProvider
 from pynguin.analyses.module import FilteredModuleTestCluster, ModuleTestCluster
 from pynguin.analyses.seeding import InitialPopulationProvider
 from pynguin.ga.algorithms.dynamosaalgorithm import DynaMOSAAlgorithm
+from pynguin.ga.algorithms.lldynamosaalgorithm import LLDynaMOSAAlgorithm
 from pynguin.ga.algorithms.llmosalgorithm import LLMOSAAlgorithm
 from pynguin.ga.algorithms.mioalgorithm import MIOAlgorithm
 from pynguin.ga.algorithms.mosaalgorithm import MOSAAlgorithm
@@ -145,6 +146,7 @@ class TestSuiteGenerationAlgorithmFactory(GenerationAlgorithmFactory[tsc.TestSui
 
     _strategies: ClassVar[dict[config.Algorithm, Callable[[], GenerationAlgorithm]]] = {
         config.Algorithm.DYNAMOSA: DynaMOSAAlgorithm,
+        config.Algorithm.LLDYNAMOSA: LLDynaMOSAAlgorithm,
         config.Algorithm.LLMOSA: LLMOSAAlgorithm,
         config.Algorithm.MIO: MIOAlgorithm,
         config.Algorithm.MOSA: MOSAAlgorithm,
@@ -223,7 +225,10 @@ class TestSuiteGenerationAlgorithmFactory(GenerationAlgorithmFactory[tsc.TestSui
             test_case_chromosome_factory = tccf.ArchiveReuseTestCaseChromosomeFactory(
                 test_case_chromosome_factory, strategy.archive
             )
-        if config.configuration.algorithm == config.Algorithm.LLMOSA:
+        if config.configuration.algorithm in {
+            config.Algorithm.LLMOSA,
+            config.Algorithm.LLDYNAMOSA,
+        }:
             return ltscf.LLMTestSuiteChromosomeFactory(
                 test_case_chromosome_factory,
                 strategy.test_factory,
@@ -342,9 +347,12 @@ class TestSuiteGenerationAlgorithmFactory(GenerationAlgorithmFactory[tsc.TestSui
             )
         # Use CoverageArchive as default, even if the algorithm does not use it.
         self._logger.info("Using CoverageArchive")
-        if config.configuration.algorithm == config.Algorithm.DYNAMOSA:
-            # DynaMOSA gradually adds its fitness functions, so we initialize
-            # with an empty set.
+        if config.configuration.algorithm in {
+            config.Algorithm.DYNAMOSA,
+            config.Algorithm.LLDYNAMOSA,
+        }:
+            # DynaMOSA (and its LLM variant) gradually adds its fitness functions, so
+            # we initialize with an empty set.
             return arch.CoverageArchive(OrderedSet())
         return arch.CoverageArchive(OrderedSet(strategy.test_case_fitness_functions))
 
@@ -365,6 +373,7 @@ class TestSuiteGenerationAlgorithmFactory(GenerationAlgorithmFactory[tsc.TestSui
         """
         if config.configuration.algorithm in {
             config.Algorithm.DYNAMOSA,
+            config.Algorithm.LLDYNAMOSA,
             config.Algorithm.MIO,
             config.Algorithm.MOSA,
             config.Algorithm.LLMOSA,

--- a/src/pynguin/generator.py
+++ b/src/pynguin/generator.py
@@ -327,9 +327,10 @@ def _setup_ml_testing_environment(test_cluster: ModuleTestCluster):
 def _verify_config() -> None:
     """Verify the configuration and raise an exception if something is invalid/not supported."""
     coverage_metrics = config.configuration.statistics_output.coverage_metrics
-    if config.configuration.algorithm is config.configuration.algorithm.DYNAMOSA and any(
-        m for m in coverage_metrics if m is not config.CoverageMetric.BRANCH
-    ):
+    if config.configuration.algorithm in {
+        config.Algorithm.DYNAMOSA,
+        config.Algorithm.LLDYNAMOSA,
+    } and any(m for m in coverage_metrics if m is not config.CoverageMetric.BRANCH):
         raise ConfigurationException(
             "DynaMosa currently only supports branch coverage as coverage criterion."
         )

--- a/tests/ga/algorithms/test_lldynamosaalgorithm.py
+++ b/tests/ga/algorithms/test_lldynamosaalgorithm.py
@@ -1,0 +1,318 @@
+#  This file is part of Pynguin.
+#
+#  SPDX-FileCopyrightText: 2019–2026 Pynguin Contributors
+#
+#  SPDX-License-Identifier: MIT
+#
+"""Tests for the DynaMOSA-LLM test-generation strategy."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import pynguin.ga.testcasechromosome as tcc
+import pynguin.ga.testsuitechromosome as tsc
+import pynguin.utils.statistics.stats as stat
+from pynguin.ga.algorithms.dynamosaalgorithm import DynaMOSAAlgorithm
+from pynguin.ga.algorithms.lldynamosaalgorithm import LLDynaMOSAAlgorithm
+from pynguin.ga.algorithms.llmosalgorithm import LLMOSAAlgorithm
+from pynguin.large_language_model.llmagent import LLMAgent
+from pynguin.utils.generic.genericaccessibleobject import (
+    GenericCallableAccessibleObject,
+)
+from pynguin.utils.report import CoverageEntry, CoverageReport, LineAnnotation
+from pynguin.utils.statistics.runtimevariable import RuntimeVariable
+
+
+@pytest.fixture
+def mock_require_api_key():
+    """Mock the require_api_key function to avoid API key validation."""
+    with patch("pynguin.large_language_model.client.require_api_key") as mock:
+        mock.return_value = MagicMock()
+        mock.return_value.get_secret_value.return_value = "test-api-key"
+        yield mock
+
+
+@pytest.fixture
+def lldynamosa_algorithm():
+    """Returns a LLDynaMOSA algorithm instance with mocked components."""
+    with (
+        patch("pynguin.large_language_model.client.require_api_key") as mock_key,
+        patch("pynguin.large_language_model.llmagent.openai.OpenAI"),
+        patch("pynguin.large_language_model.llmagent.LLMAgent", autospec=True) as mock_llm_agent,
+    ):
+        mock_key.return_value = MagicMock()
+        mock_key.return_value.get_secret_value.return_value = "test-api-key"
+        mock_model = MagicMock()
+        mock_model.llm_calls_counter = 0
+        mock_model.llm_test_case_handler = MagicMock()
+        mock_model.call_llm_for_uncovered_targets = MagicMock(return_value="test response")
+        mock_llm_agent.return_value = mock_model
+
+        algorithm = LLDynaMOSAAlgorithm()
+        # Replace the real LLMAgent with our mock
+        algorithm.model = mock_model
+
+        algorithm._logger = MagicMock()
+        algorithm._archive = MagicMock()
+        algorithm._goals_manager = MagicMock()
+        algorithm._test_case_fitness_functions = [MagicMock(), MagicMock()]
+        algorithm._test_suite_coverage_functions = [MagicMock()]
+        algorithm._chromosome_factory = MagicMock()
+        algorithm._population = []
+        algorithm.executor = MagicMock()
+        algorithm.test_cluster = MagicMock()
+        algorithm._test_factory = MagicMock()
+        algorithm._selection_function = MagicMock()
+        algorithm._crossover_function = MagicMock()
+        algorithm._ranking_function = MagicMock()
+        return algorithm
+
+
+def test_initialization():
+    """Tests that the LLDynaMOSA algorithm initializes through the full MRO chain."""
+    with patch.object(LLMAgent, "__init__", return_value=None):
+        algorithm = LLDynaMOSAAlgorithm()
+
+        assert isinstance(algorithm, LLDynaMOSAAlgorithm)
+        assert isinstance(algorithm, LLMOSAAlgorithm)
+        assert isinstance(algorithm, DynaMOSAAlgorithm)
+        assert hasattr(algorithm, "model")
+        assert isinstance(algorithm.model, LLMAgent)
+        assert algorithm._stall_intervention_count == 0
+        assert algorithm._population == []
+
+
+# ----------------------------------------------------------------------
+# Inheritance wiring: LLDynaMOSAAlgorithm extends both LLMOSAAlgorithm and
+# DynaMOSAAlgorithm. These tests check the method resolution order itself, not
+# behaviour already covered by test_llmosalgorithm.py / test_dynamosaalgorithm.py.
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "method_name",
+    [
+        "__init__",
+        "_maybe_intervene_on_stall",
+        "_enough_budget_for_llm",
+        "_diagnose_callable",
+        "_get_random_population",
+        "_breed_next_generation",
+    ],
+)
+def test_inherits_llmosa_methods_unchanged(method_name):
+    """These methods don't depend on target selection, so they should be the exact
+    same function object as LLMOSAAlgorithm's, not a reimplementation.
+    """  # noqa: D205
+    assert getattr(LLDynaMOSAAlgorithm, method_name) is getattr(LLMOSAAlgorithm, method_name)
+
+
+def test_inherits_evolve_from_dynamosa_not_mosa():
+    """evolve() must resolve to DynaMOSAAlgorithm's dynamic-target version, not
+    AbstractMOSAAlgorithm's flat-target default that LLMOSAAlgorithm/MOSAAlgorithm
+    would otherwise expose first in the MRO.
+    """  # noqa: D205
+    assert LLDynaMOSAAlgorithm.evolve is DynaMOSAAlgorithm.evolve
+
+
+@pytest.mark.parametrize(
+    "method_name",
+    [
+        "generate_tests",
+        "_target_initial_uncovered_goals",
+        "_eligible_gaos_for_targeting",
+        "target_uncovered_callables",
+    ],
+)
+def test_overrides_target_selection_methods(method_name):
+    """These are the only methods that depend on dynamic target selection, so they
+    must be defined on LLDynaMOSAAlgorithm itself, not inherited from LLMOSAAlgorithm.
+    """  # noqa: D205
+    assert method_name in LLDynaMOSAAlgorithm.__dict__
+
+
+def test_target_initial_uncovered_goals_no_llm_call(lldynamosa_algorithm):
+    """Tests that no LLM call is made when coverage is 1.0."""
+    test_suite = MagicMock(spec=tsc.TestSuiteChromosome)
+    test_suite.get_coverage.return_value = 1.0
+    lldynamosa_algorithm.create_test_suite = MagicMock(return_value=test_suite)
+
+    lldynamosa_algorithm._target_initial_uncovered_goals()
+
+    lldynamosa_algorithm.model.call_llm_for_uncovered_targets.assert_not_called()
+
+
+@patch("pynguin.ga.algorithms.lldynamosaalgorithm.config")
+def test_target_initial_uncovered_goals_with_llm_call(mock_config, lldynamosa_algorithm):
+    """Tests that an LLM call updates the goals manager, not just the archive."""
+    mock_config.configuration.large_language_model.call_llm_for_uncovered_targets = True
+    test_suite_before = MagicMock(spec=tsc.TestSuiteChromosome)
+    test_suite_before.get_coverage.return_value = 0.5
+    test_suite_after = MagicMock(spec=tsc.TestSuiteChromosome)
+    test_suite_after.get_coverage.return_value = 0.7
+
+    lldynamosa_algorithm.create_test_suite = MagicMock(
+        side_effect=[test_suite_before, test_suite_after]
+    )
+    lldynamosa_algorithm.target_uncovered_callables = MagicMock(
+        return_value=[MagicMock(spec=tcc.TestCaseChromosome)]
+    )
+
+    with patch.object(stat, "track_output_variable") as mock_track:
+        lldynamosa_algorithm._target_initial_uncovered_goals()
+
+    lldynamosa_algorithm.target_uncovered_callables.assert_called_once()
+    assert len(lldynamosa_algorithm._population) == 1
+    # DynaMOSA's UpdateTargets, not a flat archive.update(): this is the whole point
+    # of Task 1.4 -- covering a parent target via an LLM chromosome must still unlock
+    # its children.
+    lldynamosa_algorithm._goals_manager.update.assert_called_once_with(
+        lldynamosa_algorithm._population
+    )
+    lldynamosa_algorithm._archive.update.assert_not_called()
+    mock_track.assert_any_call(RuntimeVariable.CoverageBeforeLLMCall, 0.5)
+    mock_track.assert_any_call(RuntimeVariable.CoverageAfterLLMCall, 0.7)
+
+
+@patch("pynguin.ga.algorithms.lldynamosaalgorithm.config")
+def test_generate_tests_with_llm_on_stall(mock_config, lldynamosa_algorithm):
+    """Tests the generate_tests method with LLM intervention on stall detection."""
+    mock_config.configuration.large_language_model.call_llm_on_stall_detection = True
+    mock_config.configuration.large_language_model.max_llm_interventions = 2
+    mock_config.configuration.large_language_model.max_plateau_len = 1
+    mock_config.configuration.large_language_model.stall_detection_window_seconds = -1
+    mock_config.configuration.large_language_model.min_remaining_budget_for_llm = -1
+    mock_config.configuration.local_search.local_search = False
+
+    lldynamosa_algorithm.resources_left = MagicMock(side_effect=[True, True, True, False])
+
+    lldynamosa_algorithm._archive = MagicMock()
+    lldynamosa_algorithm._archive.covered_goals = []
+    lldynamosa_algorithm._archive.uncovered_goals = ["goal1", "goal2"]
+    lldynamosa_algorithm._number_of_goals = 10
+
+    lldynamosa_algorithm.before_search_start = MagicMock()
+    lldynamosa_algorithm._get_random_population = MagicMock(return_value=[])
+    lldynamosa_algorithm._target_initial_uncovered_goals = MagicMock()
+    lldynamosa_algorithm.before_first_search_iteration = MagicMock()
+    lldynamosa_algorithm.after_search_iteration = MagicMock()
+    lldynamosa_algorithm.after_search_finish = MagicMock()
+    lldynamosa_algorithm.target_uncovered_callables = MagicMock(
+        return_value=[MagicMock(spec=tcc.TestCaseChromosome)]
+    )
+    lldynamosa_algorithm.create_test_suite = MagicMock()
+    lldynamosa_algorithm.model = MagicMock()
+    lldynamosa_algorithm.model.llm_calls_counter = 0
+
+    with patch("pynguin.ga.algorithms.lldynamosaalgorithm._GoalsManager") as mock_goals_manager_cls:
+        mock_goals_manager_cls.return_value = lldynamosa_algorithm._goals_manager
+
+        def custom_evolve():
+            if lldynamosa_algorithm.evolve.call_count == 1:
+                lldynamosa_algorithm._archive.covered_goals = ["goal1"]
+
+        lldynamosa_algorithm.evolve = MagicMock(side_effect=custom_evolve)
+
+        lldynamosa_algorithm.generate_tests()
+
+    assert lldynamosa_algorithm.evolve.call_count == 3
+    lldynamosa_algorithm.after_search_finish.assert_called_once()
+
+
+@patch("pynguin.ga.algorithms.lldynamosaalgorithm.get_coverage_report")
+def test_target_uncovered_callables_queries_single_highest_priority(
+    mock_get_coverage_report, lldynamosa_algorithm
+):
+    """Tests that only the single least-covered eligible callable is queried."""
+    mock_coverage_report = MagicMock(spec=CoverageReport)
+    mock_coverage_report.line_annotations = []
+    mock_get_coverage_report.return_value = mock_coverage_report
+
+    mock_gao_low = MagicMock(spec=GenericCallableAccessibleObject)
+    mock_gao_high = MagicMock(spec=GenericCallableAccessibleObject)
+    lldynamosa_algorithm._eligible_gaos_for_targeting = MagicMock(
+        return_value={mock_gao_low, mock_gao_high}
+    )
+
+    test_chromosome = MagicMock(spec=tcc.TestCaseChromosome)
+    handler = lldynamosa_algorithm.model.llm_test_case_handler
+    handler.get_test_case_chromosomes_from_llm_results.return_value = [test_chromosome]
+
+    with (
+        patch("pynguin.ga.algorithms.lldynamosaalgorithm.config") as mock_config,
+        patch(
+            "pynguin.ga.algorithms.lldynamosaalgorithm.inspect.getsourcelines"
+        ) as mock_getsourcelines,
+    ):
+        mock_config.configuration.large_language_model.coverage_threshold = 0.8
+        mock_config.configuration.statistics_output.coverage_metrics = ["branch"]
+        # mock_gao_low ends up with a lower coverage ratio (0/10) than mock_gao_high
+        # (5/10): getsourcelines returns a different fake source range depending on
+        # which GAO is asked for, and each range's line annotations below give it a
+        # different coverage ratio.
+        mock_coverage_report.line_annotations = [
+            LineAnnotation(
+                line_no=1,
+                total=CoverageEntry(existing=10, covered=0),
+                branches=CoverageEntry(existing=0, covered=0),
+                branchless_code_objects=CoverageEntry(existing=0, covered=0),
+                lines=CoverageEntry(existing=0, covered=0),
+            ),
+            LineAnnotation(
+                line_no=101,
+                total=CoverageEntry(existing=10, covered=5),
+                branches=CoverageEntry(existing=0, covered=0),
+                branchless_code_objects=CoverageEntry(existing=0, covered=0),
+                lines=CoverageEntry(existing=0, covered=0),
+            ),
+        ]
+
+        def fake_getsourcelines(callable_):
+            if callable_ is mock_gao_low.callable:
+                return (["line1"], 1)
+            return (["line1"], 101)
+
+        mock_getsourcelines.side_effect = fake_getsourcelines
+
+        result = lldynamosa_algorithm.target_uncovered_callables()
+
+    assert len(result) == 1
+    assert result[0] == test_chromosome
+    lldynamosa_algorithm.model.call_llm_for_uncovered_targets.assert_called_once()
+    call_args = lldynamosa_algorithm.model.call_llm_for_uncovered_targets.call_args
+    queried_gao_coverage_map = call_args[0][0]
+    assert len(queried_gao_coverage_map) == 1
+
+
+def test_eligible_gaos_for_targeting_restricts_to_active_goals(lldynamosa_algorithm):
+    """Tests that only callables backing a currently-active goal are eligible."""
+    active_gao = MagicMock(spec=GenericCallableAccessibleObject)
+    inactive_gao = MagicMock(spec=GenericCallableAccessibleObject)
+
+    active_fitness = MagicMock()
+    active_fitness.goal.code_object_id = 1
+    lldynamosa_algorithm._goals_manager.current_goals = [active_fitness]
+
+    code_object_meta = MagicMock()
+    code_object_meta.code_object.co_firstlineno = 10
+    lldynamosa_algorithm.executor.subject_properties.existing_code_objects = {1: code_object_meta}
+    lldynamosa_algorithm.test_cluster.accessible_objects_under_test = [
+        active_gao,
+        inactive_gao,
+    ]
+
+    with patch(
+        "pynguin.ga.algorithms.lldynamosaalgorithm.inspect.getsourcelines"
+    ) as mock_getsourcelines:
+
+        def fake_getsourcelines(callable_):
+            if callable_ is active_gao.callable:
+                return (["l1"], 10)
+            return (["l1"], 20)
+
+        mock_getsourcelines.side_effect = fake_getsourcelines
+
+        result = lldynamosa_algorithm._eligible_gaos_for_targeting()
+
+    assert result == {active_gao}

--- a/tests/ga/test_generationalgorithmfactory.py
+++ b/tests/ga/test_generationalgorithmfactory.py
@@ -16,10 +16,13 @@ import pytest
 import pynguin.configuration as config
 import pynguin.ga.generationalgorithmfactory as gaf
 from pynguin.analyses.module import ModuleTestCluster
+from pynguin.ga.algorithms.archive import CoverageArchive
+from pynguin.ga.algorithms.lldynamosaalgorithm import LLDynaMOSAAlgorithm
 from pynguin.ga.algorithms.mosaalgorithm import MOSAAlgorithm
 from pynguin.ga.algorithms.randomalgorithm import RandomAlgorithm
 from pynguin.ga.algorithms.randomsearchalgorithm import RandomTestSuiteSearchAlgorithm
 from pynguin.ga.algorithms.wholesuitealgorithm import WholeSuiteAlgorithm
+from pynguin.ga.llmtestsuitechromosomefactory import LLMTestSuiteChromosomeFactory
 from pynguin.ga.stoppingcondition import (
     CoveragePlateauStoppingCondition,
     MaxCoverageStoppingCondition,
@@ -97,3 +100,30 @@ def test_unknown_strategy(algorithm_factory):
     config.configuration.algorithm = MagicMock()
     with pytest.raises(ConfigurationException):
         algorithm_factory.get_search_algorithm()
+
+
+def test_lldynamosa_registered_in_strategies():
+    assert (
+        gaf.TestSuiteGenerationAlgorithmFactory._strategies[config.Algorithm.LLDYNAMOSA]
+        is LLDynaMOSAAlgorithm
+    )
+
+
+def test_lldynamosa_gets_empty_archive(algorithm_factory):
+    config.configuration.algorithm = config.Algorithm.LLDYNAMOSA
+    archive = algorithm_factory._get_archive(MagicMock())
+    assert isinstance(archive, CoverageArchive)
+    assert len(archive.covered_goals) == 0
+    assert len(archive.uncovered_goals) == 0
+
+
+def test_lldynamosa_gets_llm_chromosome_factory(algorithm_factory):
+    config.configuration.algorithm = config.Algorithm.LLDYNAMOSA
+    strategy = MagicMock(
+        test_factory=MagicMock(),
+        test_cluster=MagicMock(),
+        test_case_fitness_functions=[],
+        test_suite_coverage_functions=[],
+    )
+    chromosome_factory = algorithm_factory._get_chromosome_factory(strategy)
+    assert isinstance(chromosome_factory, LLMTestSuiteChromosomeFactory)

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -419,9 +419,10 @@ def test_setup_mutant_generator_invalid_order():
         gen._setup_mutant_generator()
 
 
-def test_verify_config(tmp_path):
+@pytest.mark.parametrize("algorithm", [config.Algorithm.DYNAMOSA, config.Algorithm.LLDYNAMOSA])
+def test_verify_config(tmp_path, algorithm):
     configuration = config.Configuration(
-        algorithm=config.Algorithm.DYNAMOSA,
+        algorithm=algorithm,
         module_name="example",
         test_case_output=config.TestCaseOutputConfiguration(output_path=str(tmp_path)),
         project_path=str(tmp_path),


### PR DESCRIPTION
Adds `LLDynaMOSAAlgorithm`, combining DynaMOSA's dynamic target activation with CodaMOSA-style LLM-guided stall recovery (as `LLMOSAAlgorithm` does for MOSA). Reuses `LLMOSAAlgorithm`/`DynaMOSAAlgorithm` via multiple inheritance; overrides only the methods that depend on DynaMOSA's dynamic target set (`generate_tests`, `_target_initial_uncovered_goals`, `_eligible_gaos_for_targeting`, `target_uncovered_callables`). Registered as `Algorithm.LLDYNAMOSA`.
